### PR TITLE
EDD-22: Added custom window title bar buttons to minimize, maximize, restore and close for Windows and Linux.

### DIFF
--- a/src/app/components/Layout/Layout.jsx
+++ b/src/app/components/Layout/Layout.jsx
@@ -1,7 +1,9 @@
-import React, { useContext, useState } from 'react'
+import React, { useContext, useEffect, useState } from 'react'
 import classNames from 'classnames'
 import { FaCog } from 'react-icons/fa'
-
+import {
+  VscChromeRestore, VscChromeMaximize, VscChromeMinimize, VscChromeClose
+} from 'react-icons/vsc'
 import Button from '../Button/Button'
 import DownloadHistory from '../../pages/DownloadHistory/DownloadHistory'
 import Downloads from '../../pages/Downloads/Downloads'
@@ -12,7 +14,6 @@ import { PAGES } from '../../constants/pages'
 import { ElectronApiContext } from '../../context/ElectronApiContext'
 
 import * as styles from './Layout.module.scss'
-
 /**
  * Renders a `Layout` page.
  *
@@ -23,9 +24,21 @@ import * as styles from './Layout.module.scss'
  * )
  */
 const Layout = () => {
-  const { isMac } = useContext(ElectronApiContext)
-
+  const {
+    closeWindow,
+    minimizeWindow,
+    maximizeWindow,
+    isMac,
+    isWin,
+    isLinux,
+    windowsLinuxTitleBar
+  } = useContext(ElectronApiContext)
   const [currentPage, setCurrentPage] = useState(PAGES.downloads)
+  const [isWindowMaximized, setIsWindowMaximized] = useState(false)
+
+  const onWindowMaximized = (event, windowMaximized) => {
+    setIsWindowMaximized(windowMaximized)
+  }
 
   let pageComponent
 
@@ -49,23 +62,33 @@ const Layout = () => {
       break
   }
 
+  useEffect(() => {
+    windowsLinuxTitleBar(true, onWindowMaximized)
+
+    return () => {
+      windowsLinuxTitleBar(false, onWindowMaximized)
+    }
+  }, [])
+
   return (
     <div className={styles.wrapper}>
-      <header
-        data-testid="layout-header"
-        className={
-          classNames(
-            [
-              styles.header,
-              {
-                [styles.isMac]: isMac
-              }
-            ]
-          )
-        }
-      >
-        {/* Hiding nav buttons until EDD-18 */}
-        {/* <nav className={styles.nav}>
+      {
+        isMac && (
+          <header
+            data-testid="layout-header"
+            className={
+              classNames(
+                [
+                  styles.header,
+                  {
+                    [styles.isMac]: isMac
+                  }
+                ]
+              )
+            }
+          >
+            {/* Hiding nav buttons until EDD-18 */}
+            {/* <nav className={styles.nav}>
           <Button
             className={
               classNames(
@@ -101,18 +124,101 @@ const Layout = () => {
             Download History
           </Button>
         </nav> */}
-        <section className={styles.actions}>
-          <Button
-            className={styles.settingsButton}
-            Icon={FaCog}
-            onClick={() => setCurrentPage(PAGES.settings)}
-            dataTestId="layout-button-settings"
+            <section className={styles.actions}>
+              <Button
+                className={styles.settingsButton}
+                Icon={FaCog}
+                onClick={() => setCurrentPage(PAGES.settings)}
+                dataTestId="layout-button-settings"
+              >
+                Settings
+              </Button>
+            </section>
+          </header>
+        )
+      }
+      {
+        (isWin || isLinux) && (
+          <header
+            data-testid="windows-layout-header"
+            className={
+              classNames(
+                [
+                  styles.header,
+                  {
+                    [styles.isWin]: isWin
+                  }
+                ]
+              )
+            }
           >
-            Settings
-          </Button>
-        </section>
-      </header>
-
+            <div className={styles.windowsWrapper}>
+              <Button
+                className={styles.settingsButton}
+                Icon={FaCog}
+                onClick={() => setCurrentPage(PAGES.settings)}
+                dataTestId="layout-button-settings"
+              >
+                Settings
+              </Button>
+            </div>
+            <div className={styles.windowsButtons}>
+              <Button
+                className={
+                  classNames(
+                    [
+                      styles.minMaxCloseButton,
+                      {
+                        [styles.isLinux]: isLinux
+                      }
+                    ]
+                  )
+                }
+                onClick={() => minimizeWindow()}
+                Icon={VscChromeMinimize}
+                hideLabel
+              >
+                minimize
+              </Button>
+              <Button
+                className={
+                  classNames(
+                    [
+                      styles.minMaxCloseButton,
+                      {
+                        [styles.isLinux]: isLinux
+                      }
+                    ]
+                  )
+                }
+                onClick={() => { maximizeWindow() }}
+                Icon={isWindowMaximized && isWin ? VscChromeRestore : VscChromeMaximize}
+                hideLabel
+              >
+                maximize/restore
+              </Button>
+              <Button
+                className={
+                  classNames(
+                    [
+                      styles.minMaxCloseButton,
+                      styles.windowsClose,
+                      {
+                        [styles.isLinux]: isLinux
+                      }
+                    ]
+                  )
+                }
+                onClick={() => closeWindow()}
+                Icon={VscChromeClose}
+                hideLabel
+              >
+                close
+              </Button>
+            </div>
+          </header>
+        )
+      }
       <main className={styles.main}>
         {pageComponent}
       </main>

--- a/src/app/components/Layout/Layout.module.scss
+++ b/src/app/components/Layout/Layout.module.scss
@@ -23,10 +23,10 @@ body {
   color: #FFF;
   gap: 0 0;
   grid-area: header;
-  grid-template: "actions navigation ." 100% / 1fr auto 1fr;
+  grid-template: "actions ." 100% / 1fr auto;
 
   &.isMac {
-    grid-template: ". navigation actions" 100% / 1fr auto 1fr;
+    grid-template: ". actions" 100% / auto 1fr;
   }
 }
 
@@ -93,4 +93,44 @@ body {
   background-color: var(--color__black--050);
   grid-area: main;
   overflow-y: auto;
+}
+
+.windowsWrapper {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: flex-start;
+  color: var(--color__black--650);
+  padding-left: var(--size__200);
+}
+
+.windowsButtons {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: flex-end;
+  margin-right: var(--size__200);
+  color: var(--color__black--650);
+}
+
+.windowsClose{
+  &:hover{
+    background:  var(--color__red--500);
+  }
+}
+
+.minMaxCloseButton {
+  composes: navButton;
+  &.isLinux {
+    background-color: var(--color__blue--600);
+    border-radius: 50px;
+    font-size: 12px;
+    max-width: 20px;
+    max-height: 20px;
+    margin: 5px;
+    &:hover,
+    &:focus-visible {
+      background-color: var(--color__blue--700);
+    }
+  }
 }

--- a/src/app/components/Layout/__tests__/Layout.test.js
+++ b/src/app/components/Layout/__tests__/Layout.test.js
@@ -30,7 +30,15 @@ import Settings from '../../../pages/Settings/Settings'
 describe('Layout component', () => {
   test('renders the downloads page', () => {
     render(
-      <ElectronApiContext.Provider value={{ isMac: true }}>
+      <ElectronApiContext.Provider value={{
+        isWin: false,
+        windowsLinuxTitleBar: jest.fn(),
+        isMac: true,
+        closeWindow: jest.fn(),
+        minimizeWindow: jest.fn(),
+        maximizeWindow: jest.fn()
+      }}
+      >
         <Layout />
       </ElectronApiContext.Provider>
     )
@@ -43,7 +51,15 @@ describe('Layout component', () => {
     const user = userEvent.setup()
 
     render(
-      <ElectronApiContext.Provider value={{ isMac: true }}>
+      <ElectronApiContext.Provider value={{
+        isWin: false,
+        windowsLinuxTitleBar: jest.fn(),
+        isMac: true,
+        closeWindow: jest.fn(),
+        minimizeWindow: jest.fn(),
+        maximizeWindow: jest.fn()
+      }}
+      >
         <Layout />
       </ElectronApiContext.Provider>
     )
@@ -64,7 +80,15 @@ describe('Layout component', () => {
     const user = userEvent.setup()
 
     render(
-      <ElectronApiContext.Provider value={{ isMac: true }}>
+      <ElectronApiContext.Provider value={{
+        isWin: false,
+        windowsLinuxTitleBar: jest.fn(),
+        isMac: true,
+        closeWindow: jest.fn(),
+        minimizeWindow: jest.fn(),
+        maximizeWindow: jest.fn()
+      }}
+      >
         <Layout />
       </ElectronApiContext.Provider>
     )
@@ -80,7 +104,15 @@ describe('Layout component', () => {
     const user = userEvent.setup()
 
     render(
-      <ElectronApiContext.Provider value={{ isMac: true }}>
+      <ElectronApiContext.Provider value={{
+        isWin: false,
+        windowsLinuxTitleBar: jest.fn(),
+        isMac: true,
+        closeWindow: jest.fn(),
+        minimizeWindow: jest.fn(),
+        maximizeWindow: jest.fn()
+      }}
+      >
         <Layout />
       </ElectronApiContext.Provider>
     )
@@ -94,7 +126,15 @@ describe('Layout component', () => {
 
   test('renders the settings button on a mac', () => {
     render(
-      <ElectronApiContext.Provider value={{ isMac: true }}>
+      <ElectronApiContext.Provider value={{
+        isWin: false,
+        windowsLinuxTitleBar: jest.fn(),
+        isMac: true,
+        closeWindow: jest.fn(),
+        minimizeWindow: jest.fn(),
+        maximizeWindow: jest.fn()
+      }}
+      >
         <Layout />
       </ElectronApiContext.Provider>
     )
@@ -106,11 +146,19 @@ describe('Layout component', () => {
 
   test('renders the settings button on windows', () => {
     render(
-      <ElectronApiContext.Provider value={{ isMac: false }}>
+      <ElectronApiContext.Provider value={{
+        isWin: true,
+        windowsLinuxTitleBar: jest.fn(),
+        isMac: false,
+        closeWindow: jest.fn(),
+        minimizeWindow: jest.fn(),
+        maximizeWindow: jest.fn()
+      }}
+      >
         <Layout />
       </ElectronApiContext.Provider>
     )
 
-    expect(screen.getByTestId('layout-header').className).not.toContain('isMac')
+    expect(screen.getByTestId('windows-layout-header').className).not.toContain('isMac')
   })
 })

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -62,14 +62,7 @@ const createWindow = () => {
     y: windowState.y,
     show: false,
     title: 'Earthdata Download',
-    // TODO we want to use hiddenInset, but windows buttons aren't visible. We'll need to manually add the windows buttons, and send messages to the main process to perform the button actions.
-    // titleBarStyle: 'hiddenInset',
-    titleBarStyle: 'hidden',
-    titleBarOverlay: {
-      color: '#2A81BB',
-      symbolColor: '#FCFCFC',
-      height: 39
-    },
+    titleBarStyle: 'hiddenInset',
     frame: false,
     webPreferences: {
       preload: path.join(__dirname, 'preload.js')
@@ -103,6 +96,30 @@ const createWindow = () => {
       store,
       webContents
     })
+  })
+
+  // Title bar click event handler
+  appWindow.on('resize', () => {
+    appWindow.webContents.send('windowsLinuxTitleBar', appWindow.isMaximized())
+  })
+
+  // Maximize the Windows OS layout
+  ipcMain.on('maximizeWindow', () => {
+    if (appWindow.isMaximized()) {
+      appWindow.unmaximize()
+    } else {
+      appWindow.maximize()
+    }
+  })
+
+  // Minimize the Windows OS layout
+  ipcMain.on('minimizeWindow', () => {
+    appWindow.minimize()
+  })
+
+  // Close the Windows OS layout
+  ipcMain.on('closeWindow', () => {
+    appWindow.close()
   })
 
   ipcMain.on('chooseDownloadLocation', () => {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -15,12 +15,18 @@ contextBridge.exposeInMainWorld('electronApi', {
   cancelDownloadItem: (data) => ipcRenderer.send('cancelDownloadItem', data),
   openDownloadFolder: (data) => ipcRenderer.send('openDownloadFolder', data),
   copyDownloadPath: (data) => ipcRenderer.send('copyDownloadPath', data),
+  closeWindow: () => ipcRenderer.send('closeWindow'),
+  minimizeWindow: () => ipcRenderer.send('minimizeWindow'),
+  maximizeWindow: () => ipcRenderer.send('maximizeWindow'),
 
   // Messages to be received by the renderer process
   initializeDownload: (on, callback) => ipcRenderer[on ? 'on' : 'off']('initializeDownload', callback),
   setDownloadLocation: (on, callback) => ipcRenderer[on ? 'on' : 'off']('setDownloadLocation', callback),
   reportProgress: (on, callback) => ipcRenderer[on ? 'on' : 'off']('reportProgress', callback),
+  windowsLinuxTitleBar: (on, callback) => ipcRenderer[on ? 'on' : 'off']('windowsLinuxTitleBar', callback),
 
   // System values for renderer
-  isMac: process.platform === 'darwin'
+  isMac: process.platform === 'darwin',
+  isWin: process.platform === 'win32',
+  isLinux: process.platform === 'linux'
 })


### PR DESCRIPTION
# Overview

### What is the feature?

Added custom window title bar buttons to minimize, maximize, restore, and close for Windows and Linux.

### What is the Solution?

I have changed the Layout.jsx, Layout.module.scss, main.js, and preload.js to integrate the changes required for Windows and Linux. 

### What areas of the application does this impact?
Title bar
