### PR TITLE
EDD-22: Added custom window title bar buttons to minimize, maximize, restore, and close for Windows and Linux.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "earthdata-download",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "earthdata-download",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/eslint-parser": "^7.21.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "earthdata-download",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Earthdata Download is a cross-platform download manager designed to improve how users download Earth Science data. It accepts lists of files from applications like Earthdata Search (https://search.earthdata.nasa.gov/) and enables clients to offer users a streamlined experience when downloading files from their browser.",
   "repository": "nasa/earthdata-download",
   "homepage": "https://github.com/nasa/earthdata-download#readme",

--- a/src/app/components/Layout/Layout.jsx
+++ b/src/app/components/Layout/Layout.jsx
@@ -2,7 +2,10 @@ import React, { useContext, useEffect, useState } from 'react'
 import classNames from 'classnames'
 import { FaCog } from 'react-icons/fa'
 import {
-  VscChromeRestore, VscChromeMaximize, VscChromeMinimize, VscChromeClose
+  VscChromeRestore,
+  VscChromeMaximize,
+  VscChromeMinimize,
+  VscChromeClose
 } from 'react-icons/vsc'
 import Button from '../Button/Button'
 import DownloadHistory from '../../pages/DownloadHistory/DownloadHistory'

--- a/src/app/components/Layout/Layout.jsx
+++ b/src/app/components/Layout/Layout.jsx
@@ -1,7 +1,9 @@
-import React, { useContext, useState } from 'react'
+import React, { useContext, useEffect, useState } from 'react'
 import classNames from 'classnames'
 import { FaCog } from 'react-icons/fa'
-
+import {
+  VscChromeRestore, VscChromeMaximize, VscChromeMinimize, VscChromeClose
+} from 'react-icons/vsc'
 import Button from '../Button/Button'
 import DownloadHistory from '../../pages/DownloadHistory/DownloadHistory'
 import Downloads from '../../pages/Downloads/Downloads'
@@ -12,7 +14,6 @@ import { PAGES } from '../../constants/pages'
 import { ElectronApiContext } from '../../context/ElectronApiContext'
 
 import * as styles from './Layout.module.scss'
-
 /**
  * Renders a `Layout` page.
  *
@@ -23,9 +24,21 @@ import * as styles from './Layout.module.scss'
  * )
  */
 const Layout = () => {
-  const { isMac } = useContext(ElectronApiContext)
-
+  const {
+    closeWindow,
+    minimizeWindow,
+    maximizeWindow,
+    isMac,
+    isWin,
+    isLinux,
+    windowsLinuxTitleBar
+  } = useContext(ElectronApiContext)
   const [currentPage, setCurrentPage] = useState(PAGES.downloads)
+  const [isWindowMaximized, setIsWindowMaximized] = useState(false)
+
+  const onWindowMaximized = (event, windowMaximized) => {
+    setIsWindowMaximized(windowMaximized)
+  }
 
   let pageComponent
 
@@ -49,23 +62,33 @@ const Layout = () => {
       break
   }
 
+  useEffect(() => {
+    windowsLinuxTitleBar(true, onWindowMaximized)
+
+    return () => {
+      windowsLinuxTitleBar(false, onWindowMaximized)
+    }
+  }, [])
+
   return (
     <div className={styles.wrapper}>
-      <header
-        data-testid="layout-header"
-        className={
-          classNames(
-            [
-              styles.header,
-              {
-                [styles.isMac]: isMac
-              }
-            ]
-          )
-        }
-      >
-        {/* Hiding nav buttons until EDD-18 */}
-        {/* <nav className={styles.nav}>
+      {
+        isMac && (
+          <header
+            data-testid="layout-header"
+            className={
+              classNames(
+                [
+                  styles.header,
+                  {
+                    [styles.isMac]: isMac
+                  }
+                ]
+              )
+            }
+          >
+            {/* Hiding nav buttons until EDD-18 */}
+            {/* <nav className={styles.nav}>
           <Button
             className={
               classNames(
@@ -101,18 +124,101 @@ const Layout = () => {
             Download History
           </Button>
         </nav> */}
-        <section className={styles.actions}>
-          <Button
-            className={styles.settingsButton}
-            Icon={FaCog}
-            onClick={() => setCurrentPage(PAGES.settings)}
-            dataTestId="layout-button-settings"
+            <section className={styles.actions}>
+              <Button
+                className={styles.settingsButton}
+                Icon={FaCog}
+                onClick={() => setCurrentPage(PAGES.settings)}
+                dataTestId="layout-button-settings"
+              >
+                Settings
+              </Button>
+            </section>
+          </header>
+        )
+      }
+      {
+        (isWin || isLinux) && (
+          <header
+            data-testid="windows-layout-header"
+            className={
+              classNames(
+                [
+                  styles.header,
+                  {
+                    [styles.isWin]: isWin
+                  }
+                ]
+              )
+            }
           >
-            Settings
-          </Button>
-        </section>
-      </header>
-
+            <div className={styles.windowsWrapper}>
+              <Button
+                className={styles.settingsButton}
+                Icon={FaCog}
+                onClick={() => setCurrentPage(PAGES.settings)}
+                dataTestId="layout-button-settings"
+              >
+                Settings
+              </Button>
+            </div>
+            <div className={styles.windowsButtons}>
+              <Button
+                className={
+                  classNames(
+                    [
+                      styles.minMaxCloseButton,
+                      {
+                        [styles.isLinux]: isLinux
+                      }
+                    ]
+                  )
+                }
+                onClick={() => minimizeWindow()}
+                Icon={VscChromeMinimize}
+                hideLabel
+              >
+                minimize
+              </Button>
+              <Button
+                className={
+                  classNames(
+                    [
+                      styles.minMaxCloseButton,
+                      {
+                        [styles.isLinux]: isLinux
+                      }
+                    ]
+                  )
+                }
+                onClick={() => { maximizeWindow() }}
+                Icon={isWindowMaximized && isWin ? VscChromeRestore : VscChromeMaximize}
+                hideLabel
+              >
+                maximize/restore
+              </Button>
+              <Button
+                className={
+                  classNames(
+                    [
+                      styles.minMaxCloseButton,
+                      styles.windowsClose,
+                      {
+                        [styles.isLinux]: isLinux
+                      }
+                    ]
+                  )
+                }
+                onClick={() => closeWindow()}
+                Icon={VscChromeClose}
+                hideLabel
+              >
+                close
+              </Button>
+            </div>
+          </header>
+        )
+      }
       <main className={styles.main}>
         {pageComponent}
       </main>

--- a/src/app/components/Layout/Layout.jsx
+++ b/src/app/components/Layout/Layout.jsx
@@ -72,23 +72,21 @@ const Layout = () => {
 
   return (
     <div className={styles.wrapper}>
-      {
-        isMac && (
-          <header
-            data-testid="layout-header"
-            className={
-              classNames(
-                [
-                  styles.header,
-                  {
-                    [styles.isMac]: isMac
-                  }
-                ]
-              )
-            }
-          >
-            {/* Hiding nav buttons until EDD-18 */}
-            {/* <nav className={styles.nav}>
+      <header
+        data-testid="layout-header"
+        className={
+          classNames(
+            [
+              styles.header,
+              {
+                [styles.isMac]: isMac
+              }
+            ]
+          )
+        }
+      >
+        {/* Hiding nav buttons until EDD-18 */}
+        {/* <nav className={styles.nav}>
           <Button
             className={
               classNames(
@@ -124,101 +122,90 @@ const Layout = () => {
             Download History
           </Button>
         </nav> */}
-            <section className={styles.actions}>
-              <Button
-                className={styles.settingsButton}
-                Icon={FaCog}
-                onClick={() => setCurrentPage(PAGES.settings)}
-                dataTestId="layout-button-settings"
-              >
-                Settings
-              </Button>
-            </section>
-          </header>
-        )
-      }
-      {
-        (isWin || isLinux) && (
-          <header
-            data-testid="windows-layout-header"
-            className={
-              classNames(
-                [
-                  styles.header,
-                  {
-                    [styles.isWin]: isWin
-                  }
-                ]
-              )
-            }
+        <section
+          className={
+            classNames(
+              [
+                {
+                  [styles.actions]: isMac,
+                  [styles.windowWrapper]: isWin || isLinux
+                }
+              ]
+            )
+          }
+        >
+          <Button
+            className={styles.settingsButton}
+            Icon={FaCog}
+            onClick={() => setCurrentPage(PAGES.settings)}
+            dataTestId="layout-button-settings"
           >
-            <div className={styles.windowsWrapper}>
-              <Button
-                className={styles.settingsButton}
-                Icon={FaCog}
-                onClick={() => setCurrentPage(PAGES.settings)}
-                dataTestId="layout-button-settings"
-              >
-                Settings
-              </Button>
-            </div>
-            <div className={styles.windowsButtons}>
-              <Button
-                className={
-                  classNames(
-                    [
-                      styles.minMaxCloseButton,
-                      {
-                        [styles.isLinux]: isLinux
-                      }
-                    ]
-                  )
-                }
-                onClick={() => minimizeWindow()}
-                Icon={VscChromeMinimize}
-                hideLabel
-              >
-                minimize
-              </Button>
-              <Button
-                className={
-                  classNames(
-                    [
-                      styles.minMaxCloseButton,
-                      {
-                        [styles.isLinux]: isLinux
-                      }
-                    ]
-                  )
-                }
-                onClick={() => { maximizeWindow() }}
-                Icon={isWindowMaximized && isWin ? VscChromeRestore : VscChromeMaximize}
-                hideLabel
-              >
-                maximize/restore
-              </Button>
-              <Button
-                className={
-                  classNames(
-                    [
-                      styles.minMaxCloseButton,
-                      styles.windowsClose,
-                      {
-                        [styles.isLinux]: isLinux
-                      }
-                    ]
-                  )
-                }
-                onClick={() => closeWindow()}
-                Icon={VscChromeClose}
-                hideLabel
-              >
-                close
-              </Button>
-            </div>
-          </header>
-        )
-      }
+            Settings
+          </Button>
+        </section>
+        {(isWin || isLinux) && (
+          <div
+            data-testid="window-buttons"
+            className={styles.windowButtons}
+          >
+            <Button
+              className={
+                classNames(
+                  [
+                    styles.minMaxCloseButton,
+                    {
+                      [styles.isLinux]: isLinux
+                    }
+                  ]
+                )
+              }
+              onClick={minimizeWindow}
+              dataTestId="minimize-window"
+              Icon={VscChromeMinimize}
+              hideLabel
+            >
+              Minimize
+            </Button>
+            <Button
+              className={
+                classNames(
+                  [
+                    styles.minMaxCloseButton,
+                    {
+                      [styles.isLinux]: isLinux
+                    }
+                  ]
+                )
+              }
+              onClick={maximizeWindow}
+              dataTestId="maximize-restore-window"
+              Icon={isWindowMaximized && isWin ? VscChromeRestore : VscChromeMaximize}
+              hideLabel
+            >
+              Maximize/Restore
+            </Button>
+            <Button
+              className={
+                classNames(
+                  [
+                    styles.minMaxCloseButton,
+                    styles.windowClose,
+                    {
+                      [styles.isLinux]: isLinux
+                    }
+                  ]
+                )
+              }
+              onClick={closeWindow}
+              dataTestId="close-window"
+              Icon={VscChromeClose}
+              hideLabel
+            >
+              Close
+            </Button>
+          </div>
+        )}
+      </header>
       <main className={styles.main}>
         {pageComponent}
       </main>

--- a/src/app/components/Layout/Layout.module.scss
+++ b/src/app/components/Layout/Layout.module.scss
@@ -100,8 +100,8 @@ body {
   flex-direction: row;
   align-items: center;
   justify-content: flex-start;
-  color: var(--color__black--650);
   padding-left: var(--size__200);
+  color: var(--color__black--650);
 }
 
 .windowsButtons {
@@ -121,13 +121,15 @@ body {
 
 .minMaxCloseButton {
   composes: navButton;
+
   &.isLinux {
-    background-color: var(--color__blue--600);
-    border-radius: 50px;
-    font-size: 12px;
     max-width: 20px;
     max-height: 20px;
+    border-radius: 50px;
     margin: 5px;
+    background-color: var(--color__blue--600);
+    font-size: 12px;
+
     &:hover,
     &:focus-visible {
       background-color: var(--color__blue--700);

--- a/src/app/components/Layout/Layout.module.scss
+++ b/src/app/components/Layout/Layout.module.scss
@@ -23,10 +23,10 @@ body {
   color: #FFF;
   gap: 0 0;
   grid-area: header;
-  grid-template: "actions navigation ." 100% / 1fr auto 1fr;
+  grid-template: "actions ." 100% / 1fr auto;
 
   &.isMac {
-    grid-template: ". navigation actions" 100% / 1fr auto 1fr;
+    grid-template: ". actions" 100% / auto 1fr;
   }
 }
 
@@ -93,4 +93,44 @@ body {
   background-color: var(--color__black--050);
   grid-area: main;
   overflow-y: auto;
+}
+
+.windowsWrapper {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: flex-start;
+  color: var(--color__black--650);
+  padding-left: var(--size__200);
+}
+
+.windowsButtons {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: flex-end;
+  margin-right: var(--size__200);
+  color: var(--color__black--650);
+}
+
+.windowsClose{
+  &:hover{
+    background:  var(--color__red--500);
+  }
+}
+
+.minMaxCloseButton {
+  composes: navButton;
+  &.isLinux {
+    background-color: var(--color__blue--600);
+    border-radius: 50px;
+    font-size: 12px;
+    max-width: 20px;
+    max-height: 20px;
+    margin: 5px;
+    &:hover,
+    &:focus-visible {
+      background-color: var(--color__blue--700);
+    }
+  }
 }

--- a/src/app/components/Layout/Layout.module.scss
+++ b/src/app/components/Layout/Layout.module.scss
@@ -95,7 +95,7 @@ body {
   overflow-y: auto;
 }
 
-.windowsWrapper {
+.windowWrapper {
   display: flex;
   flex-direction: row;
   align-items: center;
@@ -104,7 +104,7 @@ body {
   color: var(--color__black--650);
 }
 
-.windowsButtons {
+.windowButtons {
   display: flex;
   flex-direction: row;
   align-items: center;
@@ -113,7 +113,7 @@ body {
   color: var(--color__black--650);
 }
 
-.windowsClose{
+.windowClose{
   &:hover{
     background:  var(--color__red--500);
   }

--- a/src/app/components/Layout/__tests__/Layout.test.js
+++ b/src/app/components/Layout/__tests__/Layout.test.js
@@ -1,6 +1,8 @@
 import React from 'react'
 
-import { render, screen } from '@testing-library/react'
+import {
+  render, screen
+} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
 import Layout from '../Layout'
@@ -32,8 +34,9 @@ describe('Layout component', () => {
     render(
       <ElectronApiContext.Provider value={{
         isWin: false,
-        windowsLinuxTitleBar: jest.fn(),
         isMac: true,
+        isLinux: false,
+        windowsLinuxTitleBar: jest.fn(),
         closeWindow: jest.fn(),
         minimizeWindow: jest.fn(),
         maximizeWindow: jest.fn()
@@ -53,8 +56,9 @@ describe('Layout component', () => {
     render(
       <ElectronApiContext.Provider value={{
         isWin: false,
-        windowsLinuxTitleBar: jest.fn(),
         isMac: true,
+        isLinux: false,
+        windowsLinuxTitleBar: jest.fn(),
         closeWindow: jest.fn(),
         minimizeWindow: jest.fn(),
         maximizeWindow: jest.fn()
@@ -82,8 +86,9 @@ describe('Layout component', () => {
     render(
       <ElectronApiContext.Provider value={{
         isWin: false,
-        windowsLinuxTitleBar: jest.fn(),
         isMac: true,
+        isLinux: false,
+        windowsLinuxTitleBar: jest.fn(),
         closeWindow: jest.fn(),
         minimizeWindow: jest.fn(),
         maximizeWindow: jest.fn()
@@ -106,8 +111,9 @@ describe('Layout component', () => {
     render(
       <ElectronApiContext.Provider value={{
         isWin: false,
-        windowsLinuxTitleBar: jest.fn(),
         isMac: true,
+        isLinux: false,
+        windowsLinuxTitleBar: jest.fn(),
         closeWindow: jest.fn(),
         minimizeWindow: jest.fn(),
         maximizeWindow: jest.fn()
@@ -128,8 +134,9 @@ describe('Layout component', () => {
     render(
       <ElectronApiContext.Provider value={{
         isWin: false,
-        windowsLinuxTitleBar: jest.fn(),
         isMac: true,
+        isLinux: false,
+        windowsLinuxTitleBar: jest.fn(),
         closeWindow: jest.fn(),
         minimizeWindow: jest.fn(),
         maximizeWindow: jest.fn()
@@ -148,8 +155,9 @@ describe('Layout component', () => {
     render(
       <ElectronApiContext.Provider value={{
         isWin: true,
-        windowsLinuxTitleBar: jest.fn(),
         isMac: false,
+        isLinux: false,
+        windowsLinuxTitleBar: jest.fn(),
         closeWindow: jest.fn(),
         minimizeWindow: jest.fn(),
         maximizeWindow: jest.fn()
@@ -159,6 +167,161 @@ describe('Layout component', () => {
       </ElectronApiContext.Provider>
     )
 
-    expect(screen.getByTestId('windows-layout-header').className).not.toContain('isMac')
+    expect(screen.getByTestId('layout-header').className).not.toContain('isMac')
+  })
+
+  test('renders the window buttons on Windows', () => {
+    render(
+      <ElectronApiContext.Provider value={{
+        isWin: true,
+        isMac: false,
+        isLinux: false,
+        windowsLinuxTitleBar: jest.fn(),
+        closeWindow: jest.fn(),
+        minimizeWindow: jest.fn(),
+        maximizeWindow: jest.fn()
+      }}
+      >
+        <Layout />
+      </ElectronApiContext.Provider>
+    )
+
+    expect(screen.getByTestId('window-buttons').className).toContain('windowButtons')
+  })
+
+  // Skipping this for now as we do not know how to check the event onWindowMaximize
+  test.skip('renders a restore button on Windows when the window is maximized', async () => {
+    const user = userEvent.setup()
+    const maximizeWindowMock = jest.fn()
+
+    render(
+      <ElectronApiContext.Provider
+        value={{
+          isWin: false,
+          isMac: false,
+          isLinux: true,
+          windowsLinuxTitleBar: jest.fn(),
+          closeWindow: jest.fn(),
+          minimizeWindow: jest.fn(),
+          maximizeWindow: maximizeWindowMock
+        }}
+      >
+        <Layout />
+      </ElectronApiContext.Provider>
+    )
+
+    await user.click(screen.getByTestId('maximize-restore-window'))
+
+    expect(maximizeWindowMock).toHaveBeenCalledTimes(1)
+  })
+
+  test('renders the window buttons on Linux', () => {
+    render(
+      <ElectronApiContext.Provider value={{
+        isWin: false,
+        isMac: false,
+        isLinux: true,
+        windowsLinuxTitleBar: jest.fn(),
+        closeWindow: jest.fn(),
+        minimizeWindow: jest.fn(),
+        maximizeWindow: jest.fn()
+      }}
+      >
+        <Layout />
+      </ElectronApiContext.Provider>
+    )
+
+    expect(screen.getByTestId('window-buttons').className).toContain('windowButtons')
+  })
+
+  test('does not render the window buttons on Mac', () => {
+    render(
+      <ElectronApiContext.Provider value={{
+        isWin: false,
+        isMac: true,
+        isLinux: false,
+        windowsLinuxTitleBar: jest.fn(),
+        closeWindow: jest.fn(),
+        minimizeWindow: jest.fn(),
+        maximizeWindow: jest.fn()
+      }}
+      >
+        <Layout />
+      </ElectronApiContext.Provider>
+    )
+
+    expect(screen.getByTestId('layout-header').className).not.toContain('windowButtons')
+  })
+
+  test('clicking the close button sends a message to the main process', async () => {
+    const user = userEvent.setup()
+    const closeWindowMock = jest.fn()
+
+    render(
+      <ElectronApiContext.Provider value={{
+        isWin: true,
+        windowsLinuxTitleBar: jest.fn(),
+        isMac: false,
+        isLinux: false,
+        closeWindow: closeWindowMock,
+        minimizeWindow: jest.fn(),
+        maximizeWindow: jest.fn()
+      }}
+      >
+        <Layout />
+      </ElectronApiContext.Provider>
+    )
+
+    await user.click(screen.getByTestId('close-window'))
+
+    expect(closeWindowMock).toHaveBeenCalledTimes(1)
+  })
+
+  test('clicking the maximize/restore button sends a message to the main process', async () => {
+    const user = userEvent.setup()
+    const maximizeWindowMock = jest.fn()
+
+    render(
+      <ElectronApiContext.Provider value={{
+        isWin: true,
+        isMac: false,
+        isLinux: false,
+        windowsLinuxTitleBar: jest.fn(),
+        closeWindow: jest.fn(),
+        minimizeWindow: jest.fn(),
+        maximizeWindow: maximizeWindowMock
+      }}
+      >
+        <Layout />
+      </ElectronApiContext.Provider>
+    )
+
+    await user.click(screen.getByTestId('maximize-restore-window'))
+
+    expect(maximizeWindowMock).toHaveBeenCalledTimes(1)
+  })
+
+  test('clicking the minimize button sends a message to the main process', async () => {
+    const user = userEvent.setup()
+    const minimizeWindowMock = jest.fn()
+
+    render(
+      <ElectronApiContext.Provider value={{
+        isWin: true,
+        isMac: false,
+        isLinux: false,
+        windowsLinuxTitleBar: jest.fn(),
+        closeWindow: jest.fn(),
+        minimizeWindow: minimizeWindowMock,
+        maximizeWindow: jest.fn()
+      }}
+      >
+        <Layout />
+      </ElectronApiContext.Provider>
+    )
+
+    await user.click(screen.getByTestId('minimize-window'))
+
+    expect(minimizeWindowMock).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/app/components/Layout/__tests__/Layout.test.js
+++ b/src/app/components/Layout/__tests__/Layout.test.js
@@ -30,7 +30,15 @@ import Settings from '../../../pages/Settings/Settings'
 describe('Layout component', () => {
   test('renders the downloads page', () => {
     render(
-      <ElectronApiContext.Provider value={{ isMac: true }}>
+      <ElectronApiContext.Provider value={{
+        isWin: false,
+        windowsLinuxTitleBar: jest.fn(),
+        isMac: true,
+        closeWindow: jest.fn(),
+        minimizeWindow: jest.fn(),
+        maximizeWindow: jest.fn()
+      }}
+      >
         <Layout />
       </ElectronApiContext.Provider>
     )
@@ -43,7 +51,15 @@ describe('Layout component', () => {
     const user = userEvent.setup()
 
     render(
-      <ElectronApiContext.Provider value={{ isMac: true }}>
+      <ElectronApiContext.Provider value={{
+        isWin: false,
+        windowsLinuxTitleBar: jest.fn(),
+        isMac: true,
+        closeWindow: jest.fn(),
+        minimizeWindow: jest.fn(),
+        maximizeWindow: jest.fn()
+      }}
+      >
         <Layout />
       </ElectronApiContext.Provider>
     )
@@ -64,7 +80,15 @@ describe('Layout component', () => {
     const user = userEvent.setup()
 
     render(
-      <ElectronApiContext.Provider value={{ isMac: true }}>
+      <ElectronApiContext.Provider value={{
+        isWin: false,
+        windowsLinuxTitleBar: jest.fn(),
+        isMac: true,
+        closeWindow: jest.fn(),
+        minimizeWindow: jest.fn(),
+        maximizeWindow: jest.fn()
+      }}
+      >
         <Layout />
       </ElectronApiContext.Provider>
     )
@@ -80,7 +104,15 @@ describe('Layout component', () => {
     const user = userEvent.setup()
 
     render(
-      <ElectronApiContext.Provider value={{ isMac: true }}>
+      <ElectronApiContext.Provider value={{
+        isWin: false,
+        windowsLinuxTitleBar: jest.fn(),
+        isMac: true,
+        closeWindow: jest.fn(),
+        minimizeWindow: jest.fn(),
+        maximizeWindow: jest.fn()
+      }}
+      >
         <Layout />
       </ElectronApiContext.Provider>
     )
@@ -94,7 +126,15 @@ describe('Layout component', () => {
 
   test('renders the settings button on a mac', () => {
     render(
-      <ElectronApiContext.Provider value={{ isMac: true }}>
+      <ElectronApiContext.Provider value={{
+        isWin: false,
+        windowsLinuxTitleBar: jest.fn(),
+        isMac: true,
+        closeWindow: jest.fn(),
+        minimizeWindow: jest.fn(),
+        maximizeWindow: jest.fn()
+      }}
+      >
         <Layout />
       </ElectronApiContext.Provider>
     )
@@ -106,11 +146,19 @@ describe('Layout component', () => {
 
   test('renders the settings button on windows', () => {
     render(
-      <ElectronApiContext.Provider value={{ isMac: false }}>
+      <ElectronApiContext.Provider value={{
+        isWin: true,
+        windowsLinuxTitleBar: jest.fn(),
+        isMac: false,
+        closeWindow: jest.fn(),
+        minimizeWindow: jest.fn(),
+        maximizeWindow: jest.fn()
+      }}
+      >
         <Layout />
       </ElectronApiContext.Provider>
     )
 
-    expect(screen.getByTestId('layout-header').className).not.toContain('isMac')
+    expect(screen.getByTestId('windows-layout-header').className).not.toContain('isMac')
   })
 })

--- a/src/app/components/Layout/__tests__/Layout.test.js
+++ b/src/app/components/Layout/__tests__/Layout.test.js
@@ -1,8 +1,5 @@
 import React from 'react'
-
-import {
-  render, screen
-} from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
 import Layout from '../Layout'

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -62,14 +62,7 @@ const createWindow = () => {
     y: windowState.y,
     show: false,
     title: 'Earthdata Download',
-    // TODO we want to use hiddenInset, but windows buttons aren't visible. We'll need to manually add the windows buttons, and send messages to the main process to perform the button actions.
-    // titleBarStyle: 'hiddenInset',
-    titleBarStyle: 'hidden',
-    titleBarOverlay: {
-      color: '#2A81BB',
-      symbolColor: '#FCFCFC',
-      height: 39
-    },
+    titleBarStyle: 'hiddenInset',
     frame: false,
     webPreferences: {
       preload: path.join(__dirname, 'preload.js')
@@ -103,6 +96,30 @@ const createWindow = () => {
       store,
       webContents
     })
+  })
+
+  // Title bar click event handler
+  appWindow.on('resize', () => {
+    appWindow.webContents.send('windowsLinuxTitleBar', appWindow.isMaximized())
+  })
+
+  // Maximize the Windows OS layout
+  ipcMain.on('maximizeWindow', () => {
+    if (appWindow.isMaximized()) {
+      appWindow.unmaximize()
+    } else {
+      appWindow.maximize()
+    }
+  })
+
+  // Minimize the Windows OS layout
+  ipcMain.on('minimizeWindow', () => {
+    appWindow.minimize()
+  })
+
+  // Close the Windows OS layout
+  ipcMain.on('closeWindow', () => {
+    appWindow.close()
   })
 
   ipcMain.on('chooseDownloadLocation', () => {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -15,12 +15,18 @@ contextBridge.exposeInMainWorld('electronApi', {
   cancelDownloadItem: (data) => ipcRenderer.send('cancelDownloadItem', data),
   openDownloadFolder: (data) => ipcRenderer.send('openDownloadFolder', data),
   copyDownloadPath: (data) => ipcRenderer.send('copyDownloadPath', data),
+  closeWindow: () => ipcRenderer.send('closeWindow'),
+  minimizeWindow: () => ipcRenderer.send('minimizeWindow'),
+  maximizeWindow: () => ipcRenderer.send('maximizeWindow'),
 
   // Messages to be received by the renderer process
   initializeDownload: (on, callback) => ipcRenderer[on ? 'on' : 'off']('initializeDownload', callback),
   setDownloadLocation: (on, callback) => ipcRenderer[on ? 'on' : 'off']('setDownloadLocation', callback),
   reportProgress: (on, callback) => ipcRenderer[on ? 'on' : 'off']('reportProgress', callback),
+  windowsLinuxTitleBar: (on, callback) => ipcRenderer[on ? 'on' : 'off']('windowsLinuxTitleBar', callback),
 
   // System values for renderer
-  isMac: process.platform === 'darwin'
+  isMac: process.platform === 'darwin',
+  isWin: process.platform === 'win32',
+  isLinux: process.platform === 'linux'
 })


### PR DESCRIPTION
What is the feature?
Added custom window title bar buttons to minimize, maximize, restore, and close for Windows and Linux.

What is the Solution?
I have changed the Layout.jsx, Layout.module.scss, main.js, and preload.js to integrate the changes required for Windows and Linux.

What areas of the application does this impact?
Title bar

# Checklist

- [X] I have added automated tests that prove my fix is effective or that my feature works
- [X ] New and existing unit tests pass locally with my changes
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have bumped the `version` field in package.json and ran `npm install`
