### PR TITLE
EDD-16: Call startNextDownload on download error

### DIFF
--- a/src/main/eventHandlers/__tests__/willDownload.test.ts
+++ b/src/main/eventHandlers/__tests__/willDownload.test.ts
@@ -7,8 +7,14 @@ import willDownload from '../willDownload'
 import sendToLogin from '../sendToLogin'
 
 import downloadStates from '../../../app/constants/downloadStates'
+import startNextDownload from '../../utils/startNextDownload'
 
 jest.mock('../sendToLogin', () => ({
+  __esModule: true,
+  default: jest.fn(() => {})
+}))
+
+jest.mock('../../utils/startNextDownload', () => ({
   __esModule: true,
   default: jest.fn(() => {})
 }))
@@ -161,6 +167,11 @@ describe('willDownload', () => {
       )
 
       expect(currentDownloadItems.addItem).toHaveBeenCalledTimes(0)
+
+      expect(startNextDownload).toHaveBeenCalledTimes(1)
+      expect(startNextDownload).toHaveBeenCalledWith(expect.objectContaining({
+        downloadId: 'shortName_version-1-20230514_012554'
+      }))
     })
   })
 

--- a/src/main/eventHandlers/willDownload.ts
+++ b/src/main/eventHandlers/willDownload.ts
@@ -3,6 +3,7 @@
 import path from 'path'
 
 import sendToLogin from './sendToLogin'
+import startNextDownload from '../utils/startNextDownload'
 
 import onDone from './willDownloadEvents/onDone'
 import onUpdated from './willDownloadEvents/onUpdated'
@@ -84,6 +85,15 @@ const willDownload = async ({
     })
 
     item.cancel()
+
+    // Start the next download
+    await startNextDownload({
+      currentDownloadItems,
+      database,
+      downloadId,
+      downloadIdContext,
+      webContents
+    })
 
     return
   }


### PR DESCRIPTION
# Overview

### What is the feature?

Fixes a bug with not starting new files if a file failed to download

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have bumped the `version` field in package.json and ran `npm install`
