### PR TITLE
EDD-43: Restarting a single file will set the download to active

### DIFF
--- a/src/main/eventHandlers/__tests__/restartDownload.test.ts
+++ b/src/main/eventHandlers/__tests__/restartDownload.test.ts
@@ -21,7 +21,7 @@ beforeEach(() => {
 
 describe('restartDownload', () => {
   describe('when only downloadId is provided', () => {
-    test('updates the files and calls startNextDownload', async () => {
+    test('updates the download and files and calls startNextDownload', async () => {
       const currentDownloadItems = {
         cancelItem: jest.fn()
       }
@@ -113,6 +113,13 @@ describe('restartDownload', () => {
         errors: null,
         receivedBytes: null,
         totalBytes: null
+      })
+
+      expect(database.updateDownloadById).toHaveBeenCalledTimes(1)
+      expect(database.updateDownloadById).toHaveBeenCalledWith('mock-download-id', {
+        errors: null,
+        state: 'ACTIVE',
+        timeEnd: null
       })
 
       expect(startNextDownload).toHaveBeenCalledTimes(1)


### PR DESCRIPTION
# Overview

### What is the feature?

When restarting a single file, if the download is not in the `active` state the file would not start downloading.

### What is the Solution?

When restarting a single file, ensure that the download is in the `active` state before calling `startNextDownload`

### What areas of the application does this impact?

Restarting files

# Testing

### Reproduction steps

Start a new download. Let the download complete, or cancel it. Click on the download to view the files. More Actions > Restart File should restart downloading the file and it should start downloading

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have bumped the `version` field in package.json and ran `npm install`
