### PR TITLE
EDD-41: As a download app user, I want to be notified of a new download starting.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "earthdata-download",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "earthdata-download",
-      "version": "0.0.17",
+      "version": "0.0.18",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "earthdata-download",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "description": "Earthdata Download is a cross-platform download manager designed to improve how users download Earth Science data. It accepts lists of files from applications like Earthdata Search (https://search.earthdata.nasa.gov/) and enables clients to offer users a streamlined experience when downloading files from their browser.",
   "repository": "nasa/earthdata-download",
   "homepage": "https://github.com/nasa/earthdata-download#readme",

--- a/src/app/components/Layout/Layout.jsx
+++ b/src/app/components/Layout/Layout.jsx
@@ -170,7 +170,6 @@ const Layout = () => {
 
       // Display a toast notification if a download is initialized
       // while current page is not Downloads
-
       if (currentPage !== PAGES.downloads) {
         newDownloadIds.forEach((downloadId) => {
           addToast({

--- a/src/app/components/Layout/Layout.jsx
+++ b/src/app/components/Layout/Layout.jsx
@@ -168,6 +168,22 @@ const Layout = () => {
         downloadLocation: newDownloadLocation,
         makeDefaultDownloadLocation: true
       })
+      // Display a toast notification if a download is initialized
+      // while current page is not Downloads
+      if (currentPage !== PAGES.downloads) {
+        downloadIds.forEach((downloadId) => {
+          addToast({
+            id: downloadId,
+            title: 'New Download',
+            message: downloadId,
+            numberErrors: 0
+          })
+        })
+      }
+    }
+    else {
+      // Return to Downloads so that the set default location dialog can be displayed
+      setCurrentPage(PAGES.downloads)
     }
   }
 
@@ -226,16 +242,22 @@ const Layout = () => {
     autoUpdateAvailable(true, onAutoUpdateAvailable)
     autoUpdateProgress(true, onAutoUpdateProgress)
     setDownloadLocation(true, onSetDownloadLocation)
-    initializeDownload(true, onInitializeDownload)
 
     return () => {
       windowsLinuxTitleBar(false, onWindowMaximized)
       autoUpdateAvailable(false, onAutoUpdateAvailable)
       autoUpdateProgress(false, onAutoUpdateProgress)
       setDownloadLocation(false, onSetDownloadLocation)
-      initializeDownload(false, onInitializeDownload)
     }
   }, [])
+
+  useEffect(() => {
+    initializeDownload(true, onInitializeDownload)
+
+    return () => {
+      initializeDownload(false, onInitializeDownload)
+    }
+  }, [currentPage])
 
   const {
     downloadId: moreInfoDownloadId,
@@ -396,7 +418,6 @@ const Layout = () => {
           dismissToast={onDismissToast}
           toasts={Object.values(activeToasts).filter(Boolean)}
         />
-
         <Dialog
           open={settingsDialogIsOpen}
           setOpen={setSettingsDialogIsOpen}
@@ -407,6 +428,8 @@ const Layout = () => {
         >
           <Settings
             hasActiveDownloads={hasActiveDownload}
+            defaultDownloadLocation={selectedDownloadLocation}
+            setDefaultDownloadLocation={setSelectedDownloadLocation}
             settingsDialogIsOpen={settingsDialogIsOpen}
           />
         </Dialog>

--- a/src/app/components/Layout/Layout.jsx
+++ b/src/app/components/Layout/Layout.jsx
@@ -168,6 +168,7 @@ const Layout = () => {
         downloadLocation: newDownloadLocation,
         makeDefaultDownloadLocation: true
       })
+
       // Display a toast notification if a download is initialized
       // while current page is not Downloads
       if (currentPage !== PAGES.downloads) {
@@ -180,8 +181,7 @@ const Layout = () => {
           })
         })
       }
-    }
-    else {
+    } else {
       // Return to Downloads so that the set default location dialog can be displayed
       setCurrentPage(PAGES.downloads)
     }

--- a/src/app/components/Layout/Layout.jsx
+++ b/src/app/components/Layout/Layout.jsx
@@ -160,7 +160,6 @@ const Layout = () => {
     setDownloadIds(newDownloadIds)
     setSelectedDownloadLocation(newDownloadLocation)
     setUseDefaultLocation(shouldUseDefaultLocation)
-
     // If shouldUseDefaultLocation is true, start the download(s)
     if (shouldUseDefaultLocation) {
       beginDownload({
@@ -171,8 +170,9 @@ const Layout = () => {
 
       // Display a toast notification if a download is initialized
       // while current page is not Downloads
+
       if (currentPage !== PAGES.downloads) {
-        downloadIds.forEach((downloadId) => {
+        newDownloadIds.forEach((downloadId) => {
           addToast({
             id: downloadId,
             title: 'New Download',

--- a/src/app/dialogs/Settings/Settings.jsx
+++ b/src/app/dialogs/Settings/Settings.jsx
@@ -22,6 +22,8 @@ import * as styles from './Settings.module.scss'
 /**
  * @typedef {Object} InitializeDownloadProps
  * @property {Boolean} hasActiveDownloads A boolean representing flag if user has downloads in active state
+ * @property {String} defaultDownloadLocation A string representing the default download file path
+ * @property {String} setDefaultDownloadLocation A function which sets default download location.
  * @property {Boolean} settingsDialogIsOpen A boolean representing flag if the settings modal is open or closed
  */
 
@@ -48,7 +50,6 @@ const Settings = ({
 }) => {
   const {
     chooseDownloadLocation,
-    setDownloadLocation,
     setPreferenceFieldValue,
     getPreferenceFieldValue
   } = useContext(ElectronApiContext)
@@ -227,9 +228,11 @@ const Settings = ({
     </div>
   )
 }
+
 Settings.defaultProps = {
-  defaultDownloadLocation: '',
+  defaultDownloadLocation: ''
 }
+
 Settings.propTypes = {
   hasActiveDownloads: PropTypes.bool.isRequired,
   defaultDownloadLocation: PropTypes.string,

--- a/src/app/dialogs/Settings/Settings.jsx
+++ b/src/app/dialogs/Settings/Settings.jsx
@@ -42,6 +42,8 @@ import * as styles from './Settings.module.scss'
  */
 const Settings = ({
   hasActiveDownloads,
+  defaultDownloadLocation,
+  setDefaultDownloadLocation,
   settingsDialogIsOpen
 }) => {
   const {
@@ -51,7 +53,6 @@ const Settings = ({
     getPreferenceFieldValue
   } = useContext(ElectronApiContext)
   const [concurrentDownloads, setConcurrentDownloads] = useState('')
-  const [defaultDownloadLocation, setDefaultDownloadLocation] = useState()
 
   const onClearDefaultDownload = () => {
     setPreferenceFieldValue({
@@ -104,15 +105,6 @@ const Settings = ({
     }
   }
 
-  const onSetDownloadLocation = (event, info) => {
-    const { downloadLocation: newDownloadLocation } = info
-    setDefaultDownloadLocation(newDownloadLocation)
-    setPreferenceFieldValue({
-      field: 'defaultDownloadLocation',
-      value: newDownloadLocation
-    })
-  }
-
   useEffect(() => {
     const fetchDefaultDownloadLocation = async () => {
       setDefaultDownloadLocation(await getPreferenceFieldValue('defaultDownloadLocation'))
@@ -128,15 +120,6 @@ const Settings = ({
     }
 
     fetchConcurrentDownloads()
-  }, [])
-
-  // Handle the response from the setDownloadLocation
-  useEffect(() => {
-    setDownloadLocation(true, onSetDownloadLocation)
-
-    return () => {
-      setDownloadLocation(false, onSetDownloadLocation)
-    }
   }, [])
 
   useEffect(() => {
@@ -244,9 +227,13 @@ const Settings = ({
     </div>
   )
 }
-
+Settings.defaultProps = {
+  defaultDownloadLocation: '',
+}
 Settings.propTypes = {
   hasActiveDownloads: PropTypes.bool.isRequired,
+  defaultDownloadLocation: PropTypes.string,
+  setDefaultDownloadLocation: PropTypes.func.isRequired,
   settingsDialogIsOpen: PropTypes.bool.isRequired
 }
 

--- a/src/app/dialogs/Settings/Settings.jsx
+++ b/src/app/dialogs/Settings/Settings.jsx
@@ -23,7 +23,7 @@ import * as styles from './Settings.module.scss'
  * @typedef {Object} InitializeDownloadProps
  * @property {Boolean} hasActiveDownloads A boolean representing flag if user has downloads in active state
  * @property {String} defaultDownloadLocation A string representing the default download file path
- * @property {String} setDefaultDownloadLocation A function which sets default download location.
+ * @property {String} setDefaultDownloadLocation A function which sets default download location
  * @property {Boolean} settingsDialogIsOpen A boolean representing flag if the settings modal is open or closed
  */
 

--- a/src/app/dialogs/Settings/__tests__/Settings.test.js
+++ b/src/app/dialogs/Settings/__tests__/Settings.test.js
@@ -17,11 +17,13 @@ const currentlyDownloadingText = 'Files currently downloading will not be affect
 const setup = (
   hasActiveDownloads,
   settingsDialogIsOpen,
-  getPreferenceFieldValue
+  getPreferenceFieldValue,
+  defaultDownloadLocation = ''
 ) => {
   // We need to mock hasActiveDownloads to render warning
   const mockHasActiveDownloads = hasActiveDownloads
   const mockSettingsDialogIsOpen = settingsDialogIsOpen
+  const mockDefaultDownloadLocation = defaultDownloadLocation
   const chooseDownloadLocation = jest.fn()
   const setDownloadLocation = jest.fn()
   const setPreferenceFieldValue = jest.fn()
@@ -45,6 +47,8 @@ const setup = (
     >
       <Settings
         hasActiveDownloads={mockHasActiveDownloads}
+        defaultDownloadLocation={mockDefaultDownloadLocation}
+        setDefaultDownloadLocation={jest.fn()}
         settingsDialogIsOpen={mockSettingsDialogIsOpen}
       />
     </ElectronApiContext.Provider>
@@ -78,7 +82,7 @@ describe('Settings dialog', () => {
     setup(hasActiveDownloads, settingsDialogIsOpen)
 
     await waitFor(() => {
-    // Can't use getByTestId, that returns an error instead of null
+      // Can't use getByTestId, that returns an error instead of null
       expect(screen.queryByText(currentlyDownloadingText)).not.toBeInTheDocument()
     })
   })
@@ -110,23 +114,26 @@ describe('Settings dialog', () => {
       return null
     })
 
-    const { setPreferenceFieldValue } = setup(
+    setup(
       hasActiveDownloads,
       settingsDialogIsOpen,
-      getPreferenceFieldValueMock
+      getPreferenceFieldValueMock,
+      '/test/location/'
     )
 
     const clearDownloadLocationButton = await screen.findByText('Clear download location')
 
     await user.click(clearDownloadLocationButton)
 
+    setup(
+      hasActiveDownloads,
+      settingsDialogIsOpen,
+      getPreferenceFieldValueMock,
+      ''
+    )
+
     await waitFor(() => {
       screen.getByText('Choose download location')
-      expect(setPreferenceFieldValue).toHaveBeenCalledTimes(1)
-      expect(setPreferenceFieldValue).toHaveBeenCalledWith({
-        field: 'defaultDownloadLocation',
-        value: null
-      })
     })
   })
 
@@ -202,6 +209,7 @@ describe('Settings dialog', () => {
       >
         <Settings
           hasActiveDownloads={false}
+          setDefaultDownloadLocation={jest.fn()}
           settingsDialogIsOpen
         />
       </ElectronApiContext.Provider>
@@ -222,6 +230,7 @@ describe('Settings dialog', () => {
       >
         <Settings
           hasActiveDownloads={false}
+          setDefaultDownloadLocation={jest.fn()}
           settingsDialogIsOpen={false}
         />
       </ElectronApiContext.Provider>

--- a/src/app/main.jsx
+++ b/src/app/main.jsx
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom/client'
 import App from './App'
 
 ReactDOM.createRoot(document.getElementById('root')).render(
-  <React.StrictMode>
+  // <React.StrictMode>
     <App />
-  </React.StrictMode>
+  // </React.StrictMode>
 )

--- a/src/app/main.jsx
+++ b/src/app/main.jsx
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom/client'
 import App from './App'
 
 ReactDOM.createRoot(document.getElementById('root')).render(
-  // <React.StrictMode>
+  <React.StrictMode>
     <App />
-  // </React.StrictMode>
+  </React.StrictMode>
 )

--- a/src/app/pages/FileDownloads/FileDownloads.jsx
+++ b/src/app/pages/FileDownloads/FileDownloads.jsx
@@ -7,7 +7,6 @@ import React, {
 import PropTypes from 'prop-types'
 import { FaDownload } from 'react-icons/fa'
 
-import { PAGES } from '../../constants/pages'
 import { REPORT_INTERVAL } from '../../constants/reportInterval'
 
 import { ElectronApiContext } from '../../context/ElectronApiContext'
@@ -47,7 +46,6 @@ const FileDownloads = ({
     deleteAllToastsById
   } = appContext
   const {
-    initializeDownload,
     requestFilesProgress,
     retryErroredDownloadItem
   } = useContext(ElectronApiContext)

--- a/src/app/pages/FileDownloads/FileDownloads.jsx
+++ b/src/app/pages/FileDownloads/FileDownloads.jsx
@@ -60,23 +60,10 @@ const FileDownloads = ({
 
   const listRef = useRef(null)
 
-  const onInitializeDownload = () => {
-    // If there is a new download return to the downloads page
-    setCurrentPage(PAGES.downloads)
-  }
-
   const onSetHideCompleted = (value) => {
     setHideCompleted(value)
     listRef.current.scrollToItem(0)
   }
-
-  useEffect(() => {
-    initializeDownload(true, onInitializeDownload)
-
-    return () => {
-      initializeDownload(false, onInitializeDownload)
-    }
-  }, [])
 
   const buildItems = (report) => {
     const {

--- a/src/app/pages/FileDownloads/__tests__/FileDownloads.test.js
+++ b/src/app/pages/FileDownloads/__tests__/FileDownloads.test.js
@@ -22,7 +22,6 @@ jest.mock('../../../utils/addErrorToasts', () => ({
 const setup = (withErrors, overrideProps) => {
   const addToast = jest.fn()
   const deleteAllToastsById = jest.fn()
-  const initializeDownload = jest.fn()
   const setCurrentPage = jest.fn()
   const showMoreInfoDialog = jest.fn()
 
@@ -87,7 +86,6 @@ const setup = (withErrors, overrideProps) => {
   render(
     <ElectronApiContext.Provider value={
       {
-        initializeDownload,
         requestFilesProgress
       }
     }
@@ -109,7 +107,6 @@ const setup = (withErrors, overrideProps) => {
   return {
     addToast,
     deleteAllToastsById,
-    initializeDownload,
     requestFilesProgress,
     setCurrentPage,
     showMoreInfoDialog

--- a/src/main/__tests__/preload.test.ts
+++ b/src/main/__tests__/preload.test.ts
@@ -11,7 +11,7 @@ jest.mock(
       send: jest.fn(),
       invoke: jest.fn(),
       on: jest.fn(),
-      removeListener: jest.fn()
+      removeAllListeners: jest.fn()
     }
     const mockContextBridge = {
       exposeInMainWorld: (name, events) => {
@@ -240,10 +240,10 @@ describe('preload', () => {
 
       expect(ipcRenderer.on).toHaveBeenCalledTimes(1)
       expect(ipcRenderer.on).toHaveBeenCalledWith('autoUpdateAvailable', mockCallback)
-      expect(ipcRenderer.removeListener).toHaveBeenCalledTimes(0)
+      expect(ipcRenderer.removeAllListeners).toHaveBeenCalledTimes(0)
     })
 
-    test('calls ipcRenderer.removeListener', async () => {
+    test('calls ipcRenderer.removeAllListeners', async () => {
       await setup()
 
       const mockCallback = jest.fn()
@@ -251,8 +251,8 @@ describe('preload', () => {
       electronApi.autoUpdateAvailable(false, mockCallback)
 
       expect(ipcRenderer.on).toHaveBeenCalledTimes(0)
-      expect(ipcRenderer.removeListener).toHaveBeenCalledTimes(1)
-      expect(ipcRenderer.removeListener).toHaveBeenCalledWith('autoUpdateAvailable', mockCallback)
+      expect(ipcRenderer.removeAllListeners).toHaveBeenCalledTimes(1)
+      expect(ipcRenderer.removeAllListeners).toHaveBeenCalledWith('autoUpdateAvailable', mockCallback)
     })
   })
 
@@ -266,10 +266,10 @@ describe('preload', () => {
 
       expect(ipcRenderer.on).toHaveBeenCalledTimes(1)
       expect(ipcRenderer.on).toHaveBeenCalledWith('autoUpdateProgress', mockCallback)
-      expect(ipcRenderer.removeListener).toHaveBeenCalledTimes(0)
+      expect(ipcRenderer.removeAllListeners).toHaveBeenCalledTimes(0)
     })
 
-    test('calls ipcRenderer.removeListener', async () => {
+    test('calls ipcRenderer.removeAllListeners', async () => {
       await setup()
 
       const mockCallback = jest.fn()
@@ -277,8 +277,8 @@ describe('preload', () => {
       electronApi.autoUpdateProgress(false, mockCallback)
 
       expect(ipcRenderer.on).toHaveBeenCalledTimes(0)
-      expect(ipcRenderer.removeListener).toHaveBeenCalledTimes(1)
-      expect(ipcRenderer.removeListener).toHaveBeenCalledWith('autoUpdateProgress', mockCallback)
+      expect(ipcRenderer.removeAllListeners).toHaveBeenCalledTimes(1)
+      expect(ipcRenderer.removeAllListeners).toHaveBeenCalledWith('autoUpdateProgress', mockCallback)
     })
   })
 
@@ -292,10 +292,10 @@ describe('preload', () => {
 
       expect(ipcRenderer.on).toHaveBeenCalledTimes(1)
       expect(ipcRenderer.on).toHaveBeenCalledWith('initializeDownload', mockCallback)
-      expect(ipcRenderer.removeListener).toHaveBeenCalledTimes(0)
+      expect(ipcRenderer.removeAllListeners).toHaveBeenCalledTimes(0)
     })
 
-    test('calls ipcRenderer.removeListener', async () => {
+    test('calls ipcRenderer.removeAllListeners', async () => {
       await setup()
 
       const mockCallback = jest.fn()
@@ -303,8 +303,8 @@ describe('preload', () => {
       electronApi.initializeDownload(false, mockCallback)
 
       expect(ipcRenderer.on).toHaveBeenCalledTimes(0)
-      expect(ipcRenderer.removeListener).toHaveBeenCalledTimes(1)
-      expect(ipcRenderer.removeListener).toHaveBeenCalledWith('initializeDownload', mockCallback)
+      expect(ipcRenderer.removeAllListeners).toHaveBeenCalledTimes(1)
+      expect(ipcRenderer.removeAllListeners).toHaveBeenCalledWith('initializeDownload', mockCallback)
     })
   })
 
@@ -318,10 +318,10 @@ describe('preload', () => {
 
       expect(ipcRenderer.on).toHaveBeenCalledTimes(1)
       expect(ipcRenderer.on).toHaveBeenCalledWith('setDownloadLocation', mockCallback)
-      expect(ipcRenderer.removeListener).toHaveBeenCalledTimes(0)
+      expect(ipcRenderer.removeAllListeners).toHaveBeenCalledTimes(0)
     })
 
-    test('calls ipcRenderer.removeListener', async () => {
+    test('calls ipcRenderer.removeAllListeners', async () => {
       await setup()
 
       const mockCallback = jest.fn()
@@ -329,8 +329,8 @@ describe('preload', () => {
       electronApi.setDownloadLocation(false, mockCallback)
 
       expect(ipcRenderer.on).toHaveBeenCalledTimes(0)
-      expect(ipcRenderer.removeListener).toHaveBeenCalledTimes(1)
-      expect(ipcRenderer.removeListener).toHaveBeenCalledWith('setDownloadLocation', mockCallback)
+      expect(ipcRenderer.removeAllListeners).toHaveBeenCalledTimes(1)
+      expect(ipcRenderer.removeAllListeners).toHaveBeenCalledWith('setDownloadLocation', mockCallback)
     })
   })
 
@@ -344,10 +344,10 @@ describe('preload', () => {
 
       expect(ipcRenderer.on).toHaveBeenCalledTimes(1)
       expect(ipcRenderer.on).toHaveBeenCalledWith('showWaitingForEulaDialog', mockCallback)
-      expect(ipcRenderer.removeListener).toHaveBeenCalledTimes(0)
+      expect(ipcRenderer.removeAllListeners).toHaveBeenCalledTimes(0)
     })
 
-    test('calls ipcRenderer.removeListener', async () => {
+    test('calls ipcRenderer.removeAllListeners', async () => {
       await setup()
 
       const mockCallback = jest.fn()
@@ -355,8 +355,8 @@ describe('preload', () => {
       electronApi.showWaitingForEulaDialog(false, mockCallback)
 
       expect(ipcRenderer.on).toHaveBeenCalledTimes(0)
-      expect(ipcRenderer.removeListener).toHaveBeenCalledTimes(1)
-      expect(ipcRenderer.removeListener).toHaveBeenCalledWith('showWaitingForEulaDialog', mockCallback)
+      expect(ipcRenderer.removeAllListeners).toHaveBeenCalledTimes(1)
+      expect(ipcRenderer.removeAllListeners).toHaveBeenCalledWith('showWaitingForEulaDialog', mockCallback)
     })
   })
 
@@ -370,10 +370,10 @@ describe('preload', () => {
 
       expect(ipcRenderer.on).toHaveBeenCalledTimes(1)
       expect(ipcRenderer.on).toHaveBeenCalledWith('showWaitingForLoginDialog', mockCallback)
-      expect(ipcRenderer.removeListener).toHaveBeenCalledTimes(0)
+      expect(ipcRenderer.removeAllListeners).toHaveBeenCalledTimes(0)
     })
 
-    test('calls ipcRenderer.removeListener', async () => {
+    test('calls ipcRenderer.removeAllListeners', async () => {
       await setup()
 
       const mockCallback = jest.fn()
@@ -381,8 +381,8 @@ describe('preload', () => {
       electronApi.showWaitingForLoginDialog(false, mockCallback)
 
       expect(ipcRenderer.on).toHaveBeenCalledTimes(0)
-      expect(ipcRenderer.removeListener).toHaveBeenCalledTimes(1)
-      expect(ipcRenderer.removeListener).toHaveBeenCalledWith('showWaitingForLoginDialog', mockCallback)
+      expect(ipcRenderer.removeAllListeners).toHaveBeenCalledTimes(1)
+      expect(ipcRenderer.removeAllListeners).toHaveBeenCalledWith('showWaitingForLoginDialog', mockCallback)
     })
   })
 
@@ -396,10 +396,10 @@ describe('preload', () => {
 
       expect(ipcRenderer.on).toHaveBeenCalledTimes(1)
       expect(ipcRenderer.on).toHaveBeenCalledWith('windowsLinuxTitleBar', mockCallback)
-      expect(ipcRenderer.removeListener).toHaveBeenCalledTimes(0)
+      expect(ipcRenderer.removeAllListeners).toHaveBeenCalledTimes(0)
     })
 
-    test('calls ipcRenderer.removeListener', async () => {
+    test('calls ipcRenderer.removeAllListeners', async () => {
       await setup()
 
       const mockCallback = jest.fn()
@@ -407,8 +407,8 @@ describe('preload', () => {
       electronApi.windowsLinuxTitleBar(false, mockCallback)
 
       expect(ipcRenderer.on).toHaveBeenCalledTimes(0)
-      expect(ipcRenderer.removeListener).toHaveBeenCalledTimes(1)
-      expect(ipcRenderer.removeListener).toHaveBeenCalledWith('windowsLinuxTitleBar', mockCallback)
+      expect(ipcRenderer.removeAllListeners).toHaveBeenCalledTimes(1)
+      expect(ipcRenderer.removeAllListeners).toHaveBeenCalledWith('windowsLinuxTitleBar', mockCallback)
     })
   })
 })

--- a/src/main/eventHandlers/__tests__/chooseDownloadLocation.test.ts
+++ b/src/main/eventHandlers/__tests__/chooseDownloadLocation.test.ts
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 import { dialog } from 'electron'
 
 import chooseDownloadLocation from '../chooseDownloadLocation'

--- a/src/main/eventHandlers/__tests__/chooseDownloadLocation.test.ts
+++ b/src/main/eventHandlers/__tests__/chooseDownloadLocation.test.ts
@@ -1,9 +1,11 @@
+// @ts-nocheck
+
 import { dialog } from 'electron'
 
 import chooseDownloadLocation from '../chooseDownloadLocation'
 
 describe('chooseDownloadLocation', () => {
-  test('returns if no location was selected', () => {
+  test('returns if no location was selected', async () => {
     dialog.showOpenDialogSync = jest.fn().mockReturnValue(undefined)
 
     const appWindow = {
@@ -11,13 +13,19 @@ describe('chooseDownloadLocation', () => {
         send: jest.fn()
       }
     }
+    const database = {
+      setPreferences: jest.fn()
+    }
 
-    chooseDownloadLocation({ appWindow })
+    await chooseDownloadLocation({
+      appWindow,
+      database
+    })
 
     expect(appWindow.webContents.send).toHaveBeenCalledTimes(0)
   })
 
-  test('sends the selected download location to the renderer process', () => {
+  test('sends the selected download location to the renderer process', async () => {
     dialog.showOpenDialogSync = jest.fn().mockReturnValue(['/mock/path'])
 
     const appWindow = {
@@ -25,8 +33,21 @@ describe('chooseDownloadLocation', () => {
         send: jest.fn()
       }
     }
+    const database = {
+      setPreferences: jest.fn()
+    }
 
-    chooseDownloadLocation({ appWindow })
+    await chooseDownloadLocation({
+      appWindow,
+      database
+    })
+
+    expect(database.setPreferences).toHaveBeenCalledTimes(1)
+    expect(database.setPreferences).toHaveBeenCalledWith(
+      {
+        defaultDownloadLocation: '/mock/path'
+      }
+    )
 
     expect(appWindow.webContents.send).toHaveBeenCalledTimes(1)
     expect(appWindow.webContents.send).toHaveBeenCalledWith('setDownloadLocation', { downloadLocation: '/mock/path' })

--- a/src/main/eventHandlers/chooseDownloadLocation.ts
+++ b/src/main/eventHandlers/chooseDownloadLocation.ts
@@ -4,11 +4,12 @@ import { dialog } from 'electron'
 
 /**
  * Opens the electron open dialog to choose a download location
- * @param {Object} params
+ * @param {Object} psarams
  * @param {Object} params.appWindow Electron window instance
  */
-const chooseDownloadLocation = ({
-  appWindow
+const chooseDownloadLocation = async ({
+  appWindow,
+  database
 }) => {
   const result = dialog.showOpenDialogSync(null, {
     message: 'Where would you like to download your files?',
@@ -23,6 +24,10 @@ const chooseDownloadLocation = ({
   if (!result) return
 
   const [downloadLocation] = result
+
+  await database.setPreferences({
+    defaultDownloadLocation: downloadLocation
+  })
 
   // Send a message back to the renderer with the downloadLocation
   appWindow.webContents.send('setDownloadLocation', { downloadLocation })

--- a/src/main/eventHandlers/chooseDownloadLocation.ts
+++ b/src/main/eventHandlers/chooseDownloadLocation.ts
@@ -4,7 +4,7 @@ import { dialog } from 'electron'
 
 /**
  * Opens the electron open dialog to choose a download location
- * @param {Object} psarams
+ * @param {Object} params
  * @param {Object} params.appWindow Electron window instance
  */
 const chooseDownloadLocation = async ({

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -33,13 +33,13 @@ contextBridge.exposeInMainWorld('electronApi', {
   requestFilesProgress: (data) => ipcRenderer.invoke('requestFilesProgress', data),
 
   // Messages to be received by the renderer process
-  autoUpdateAvailable: (on, callback) => ipcRenderer[on ? 'on' : 'removeListener']('autoUpdateAvailable', callback),
-  autoUpdateProgress: (on, callback) => ipcRenderer[on ? 'on' : 'removeListener']('autoUpdateProgress', callback),
-  initializeDownload: (on, callback) => ipcRenderer[on ? 'on' : 'removeListener']('initializeDownload', callback),
-  setDownloadLocation: (on, callback) => ipcRenderer[on ? 'on' : 'removeListener']('setDownloadLocation', callback),
-  showWaitingForEulaDialog: (on, callback) => ipcRenderer[on ? 'on' : 'removeListener']('showWaitingForEulaDialog', callback),
-  showWaitingForLoginDialog: (on, callback) => ipcRenderer[on ? 'on' : 'removeListener']('showWaitingForLoginDialog', callback),
-  windowsLinuxTitleBar: (on, callback) => ipcRenderer[on ? 'on' : 'removeListener']('windowsLinuxTitleBar', callback),
+  autoUpdateAvailable: (on, callback) => ipcRenderer[on ? 'on' : 'removeAllListeners']('autoUpdateAvailable', callback),
+  autoUpdateProgress: (on, callback) => ipcRenderer[on ? 'on' : 'removeAllListeners']('autoUpdateProgress', callback),
+  initializeDownload: (on, callback) => ipcRenderer[on ? 'on' : 'removeAllListeners']('initializeDownload', callback),
+  setDownloadLocation: (on, callback) => ipcRenderer[on ? 'on' : 'removeAllListeners']('setDownloadLocation', callback),
+  showWaitingForEulaDialog: (on, callback) => ipcRenderer[on ? 'on' : 'removeAllListeners']('showWaitingForEulaDialog', callback),
+  showWaitingForLoginDialog: (on, callback) => ipcRenderer[on ? 'on' : 'removeAllListeners']('showWaitingForLoginDialog', callback),
+  windowsLinuxTitleBar: (on, callback) => ipcRenderer[on ? 'on' : 'removeAllListeners']('windowsLinuxTitleBar', callback),
 
   // System values for renderer
   isMac: process.platform === 'darwin',

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -40,7 +40,6 @@ contextBridge.exposeInMainWorld('electronApi', {
   showWaitingForEulaDialog: (on, callback) => ipcRenderer[on ? 'on' : 'removeAllListeners']('showWaitingForEulaDialog', callback),
   showWaitingForLoginDialog: (on, callback) => ipcRenderer[on ? 'on' : 'removeAllListeners']('showWaitingForLoginDialog', callback),
   windowsLinuxTitleBar: (on, callback) => ipcRenderer[on ? 'on' : 'removeAllListeners']('windowsLinuxTitleBar', callback),
-
   // System values for renderer
   isMac: process.platform === 'darwin',
   isWin: process.platform === 'win32',

--- a/src/main/utils/__tests__/setupEventListeners.test.ts
+++ b/src/main/utils/__tests__/setupEventListeners.test.ts
@@ -262,12 +262,15 @@ describe('setupEventListeners', () => {
 
   describe('chooseDownloadLocation', () => {
     test('calls chooseDownloadLocation', () => {
-      const { appWindow } = setup()
+      const { appWindow, database } = setup()
 
       ipcRenderer.send('chooseDownloadLocation')
 
       expect(chooseDownloadLocation).toHaveBeenCalledTimes(1)
-      expect(chooseDownloadLocation).toHaveBeenCalledWith({ appWindow })
+      expect(chooseDownloadLocation).toHaveBeenCalledWith({
+        appWindow,
+        database
+      })
     })
   })
 

--- a/src/main/utils/setupEventListeners.ts
+++ b/src/main/utils/setupEventListeners.ts
@@ -79,9 +79,10 @@ const setupEventListeners = ({
   })
 
   // Show the choose download dialog
-  ipcMain.on('chooseDownloadLocation', () => {
-    chooseDownloadLocation({
-      appWindow
+  ipcMain.on('chooseDownloadLocation', async () => {
+    await chooseDownloadLocation({
+      appWindow,
+      database
     })
   })
 


### PR DESCRIPTION
# Overview

### What is the feature?

Notification when a new download is started when not on Downloads page.

### What is the Solution?

I added a toast notification that fires when the onInitializeDownload listener in Layout receives and event and the currentPage is not downloads.  I also adjusted the preload.ts file listener setup to call removeAllListeners instead of removeListener, as we were running into issues receiving the message properly due to orphaned listeners.

### What areas of the application does this impact?

Layout.jsx, Settings.jsx and FileDownloads.jsx

# Testing

### Reproduction steps

1. Start a download
2. Navigate to fileDownloads page
3. Start another download
4. View toast notification

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have bumped the `version` field in package.json and ran `npm install`
