### PR TITLE
EDD-19: As a download app user, I want to be able to clear my download history.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "earthdata-download",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "earthdata-download",
-      "version": "0.0.19",
+      "version": "0.0.20",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "earthdata-download",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "description": "Earthdata Download is a cross-platform download manager designed to improve how users download Earth Science data. It accepts lists of files from applications like Earthdata Search (https://search.earthdata.nasa.gov/) and enables clients to offer users a streamlined experience when downloading files from their browser.",
   "repository": "nasa/earthdata-download",
   "homepage": "https://github.com/nasa/earthdata-download#readme",

--- a/src/app/components/DownloadHistoryHeader/DownloadHistoryHeader.jsx
+++ b/src/app/components/DownloadHistoryHeader/DownloadHistoryHeader.jsx
@@ -1,6 +1,7 @@
-import React from 'react'
+import React, { useContext } from 'react'
 import { FaBan } from 'react-icons/fa'
 import useAppContext from '../../hooks/useAppContext'
+import { ElectronApiContext } from '../../context/ElectronApiContext'
 
 import Button from '../Button/Button'
 
@@ -19,14 +20,13 @@ const DownloadHistoryHeader = () => {
   const {
     deleteAllToastsById
   } = appContext
-  // TODO EDD-19
-  // const {
-  //   clearDownloadHistory
-  // } = useContext(ElectronApiContext)
+
+  const {
+    clearDownloadHistory
+  } = useContext(ElectronApiContext)
 
   const onClearDownloadHistory = () => {
-    // TODO EDD-19
-    // clearDownloadHistory()
+    clearDownloadHistory({})
     deleteAllToastsById()
   }
 

--- a/src/app/components/DownloadHistoryHeader/__tests__/DownloadHistoryHeader.test.js
+++ b/src/app/components/DownloadHistoryHeader/__tests__/DownloadHistoryHeader.test.js
@@ -49,6 +49,7 @@ describe('DownloadHistoryHeader component', () => {
       await userEvent.click(button)
 
       expect(clearDownloadHistory).toHaveBeenCalledTimes(1)
+      expect(clearDownloadHistory).toHaveBeenCalledWith({})
       expect(deleteAllToastsById).toHaveBeenCalledTimes(1)
     })
   })

--- a/src/app/components/DownloadHistoryHeader/__tests__/DownloadHistoryHeader.test.js
+++ b/src/app/components/DownloadHistoryHeader/__tests__/DownloadHistoryHeader.test.js
@@ -48,7 +48,7 @@ describe('DownloadHistoryHeader component', () => {
       const button = screen.getByRole('button', { name: 'Clear Download History' })
       await userEvent.click(button)
 
-      expect(clearDownloadHistory).toHaveBeenCalledTimes(0)
+      expect(clearDownloadHistory).toHaveBeenCalledTimes(1)
       expect(deleteAllToastsById).toHaveBeenCalledTimes(1)
     })
   })

--- a/src/app/components/DownloadHistoryListItem/DownloadHistoryListItem.jsx
+++ b/src/app/components/DownloadHistoryListItem/DownloadHistoryListItem.jsx
@@ -1,6 +1,7 @@
 import React, { useContext } from 'react'
 import PropTypes from 'prop-types'
 import {
+  FaBan,
   FaClipboard,
   FaFolderOpen,
   FaInfoCircle
@@ -42,6 +43,7 @@ const DownloadHistoryListItem = ({
     deleteAllToastsById
   } = appContext
   const {
+    clearDownloadHistory,
     copyDownloadPath,
     openDownloadFolder,
     restartDownload
@@ -90,6 +92,16 @@ const DownloadHistoryListItem = ({
           restartDownload({ downloadId })
         },
         icon: FaInfoCircle
+      },
+      {
+        label: 'Clear Download',
+        isActive: true,
+        isPrimary: false,
+        callback: () => {
+          deleteAllToastsById(downloadId)
+          clearDownloadHistory({ downloadId })
+        },
+        icon: FaBan
       }
     ]
   ]

--- a/src/app/components/DownloadHistoryListItem/DownloadHistoryListItem.jsx
+++ b/src/app/components/DownloadHistoryListItem/DownloadHistoryListItem.jsx
@@ -106,9 +106,23 @@ const DownloadHistoryListItem = ({
     ]
   ]
 
+  const fetchLinksErroredActionsList = [
+    [
+      {
+        label: 'Clear Download',
+        isActive: true,
+        isPrimary: false,
+        callback: () => {
+          deleteAllToastsById(downloadId)
+          clearDownloadHistory({ downloadId })
+        },
+        icon: FaBan
+      }
+    ], []]
+
   return (
     <DownloadItem
-      actionsList={shouldShowActions ? actionsList : null}
+      actionsList={shouldShowActions ? actionsList : fetchLinksErroredActionsList}
       downloadId={downloadId}
       showMoreInfoDialog={showMoreInfoDialog}
       shouldBeClickable={false}

--- a/src/app/components/DownloadHistoryListItem/__tests__/DownloadHistoryListItem.test.js
+++ b/src/app/components/DownloadHistoryListItem/__tests__/DownloadHistoryListItem.test.js
@@ -28,6 +28,7 @@ const download = {
 
 const setup = (overrideProps = {}) => {
   const deleteAllToastsById = jest.fn()
+  const clearDownloadHistory = jest.fn()
   const copyDownloadPath = jest.fn()
   const openDownloadFolder = jest.fn()
   const restartDownload = jest.fn()
@@ -45,6 +46,7 @@ const setup = (overrideProps = {}) => {
     <ElectronApiContext.Provider
       value={
         {
+          clearDownloadHistory,
           copyDownloadPath,
           openDownloadFolder,
           restartDownload,
@@ -67,6 +69,7 @@ const setup = (overrideProps = {}) => {
 
   return {
     deleteAllToastsById,
+    clearDownloadHistory,
     copyDownloadPath,
     openDownloadFolder,
     restartDownload
@@ -153,6 +156,24 @@ describe('DownloadHistoryListItem component', () => {
       await userEvent.click(button)
 
       expect(restartDownload).toHaveBeenCalledTimes(1)
+
+      expect(deleteAllToastsById).toHaveBeenCalledTimes(1)
+      expect(deleteAllToastsById).toHaveBeenCalledWith('mock-download-id')
+    })
+  })
+
+  describe('when clicking `Clear Download`', () => {
+    test('calls clearDownloadHistory', async () => {
+      const { clearDownloadHistory, deleteAllToastsById } = setup()
+
+      const moreActions = screen.getByText('More Actions')
+      await userEvent.click(moreActions)
+
+      const button = screen.getByText('Clear Download')
+      await userEvent.click(button)
+
+      expect(clearDownloadHistory).toHaveBeenCalledTimes(1)
+      expect(clearDownloadHistory).toHaveBeenCalledWith({ downloadId: 'mock-download-id' })
 
       expect(deleteAllToastsById).toHaveBeenCalledTimes(1)
       expect(deleteAllToastsById).toHaveBeenCalledWith('mock-download-id')

--- a/src/app/components/DownloadHistoryListItem/__tests__/DownloadHistoryListItem.test.js
+++ b/src/app/components/DownloadHistoryListItem/__tests__/DownloadHistoryListItem.test.js
@@ -26,6 +26,20 @@ const download = {
   timeStart: 123000
 }
 
+const erroredFetchLinksdownload = {
+  errors: null,
+  loadingMoreFiles: false,
+  progress: {
+    percent: 100,
+    finishedFiles: 10,
+    totalFiles: 10,
+    totalTime: 567000
+  },
+  downloadId: 'mock-download-id',
+  state: downloadStates.errorFetchingLinks,
+  timeStart: 123000
+}
+
 const setup = (overrideProps = {}) => {
   const deleteAllToastsById = jest.fn()
   const clearDownloadHistory = jest.fn()
@@ -171,6 +185,31 @@ describe('DownloadHistoryListItem component', () => {
 
       const button = screen.getByText('Clear Download')
       await userEvent.click(button)
+
+      expect(clearDownloadHistory).toHaveBeenCalledTimes(1)
+      expect(clearDownloadHistory).toHaveBeenCalledWith({ downloadId: 'mock-download-id' })
+
+      expect(deleteAllToastsById).toHaveBeenCalledTimes(1)
+      expect(deleteAllToastsById).toHaveBeenCalledWith('mock-download-id')
+    })
+  })
+
+  describe('when a `downloadHistoryListItem` is in `errorFetchingLinks` state', () => {
+    test(' clicking `Clear Download` clearDownloadHistory', async () => {
+      const { clearDownloadHistory, deleteAllToastsById } = setup(
+        { download: erroredFetchLinksdownload }
+      )
+      const moreActions = screen.getByText('More Actions')
+      await userEvent.click(moreActions)
+
+      // Ensure the other buttons are not rendering
+      expect(screen.queryAllByText('Open Folder').length).toEqual(0)
+      expect(screen.queryAllByText('Copy Folder Path').length).toEqual(0)
+      expect(screen.queryAllByText('Copy Folder Path').length).toEqual(0)
+      expect(screen.queryAllByText('Restart Download').length).toEqual(0)
+
+      const Clearbutton = screen.getByText('Clear Download')
+      await userEvent.click(Clearbutton)
 
       expect(clearDownloadHistory).toHaveBeenCalledTimes(1)
       expect(clearDownloadHistory).toHaveBeenCalledWith({ downloadId: 'mock-download-id' })

--- a/src/main/__tests__/preload.test.ts
+++ b/src/main/__tests__/preload.test.ts
@@ -133,6 +133,7 @@ describe('preload', () => {
 
   test('clearDownloadHistory sends the clearDownloadHistory message', async () => {
     await setup()
+
     electronApi.clearDownloadHistory({ mock: 'data' })
 
     expect(ipcRenderer.send).toHaveBeenCalledTimes(1)

--- a/src/main/__tests__/preload.test.ts
+++ b/src/main/__tests__/preload.test.ts
@@ -133,11 +133,10 @@ describe('preload', () => {
 
   test('clearDownloadHistory sends the clearDownloadHistory message', async () => {
     await setup()
-
-    electronApi.clearDownloadHistory()
+    electronApi.clearDownloadHistory({ mock: 'data' })
 
     expect(ipcRenderer.send).toHaveBeenCalledTimes(1)
-    expect(ipcRenderer.send).toHaveBeenCalledWith('clearDownloadHistory')
+    expect(ipcRenderer.send).toHaveBeenCalledWith('clearDownloadHistory', { mock: 'data' })
   })
 
   test('closeWindow sends the closeWindow message', async () => {

--- a/src/main/eventHandlers/__tests__/clearDownloadHistory.test.js
+++ b/src/main/eventHandlers/__tests__/clearDownloadHistory.test.js
@@ -1,0 +1,40 @@
+import clearDownloadHistory from '../clearDownloadHistory'
+
+describe('clearDownloadHistory', () => {
+  describe('when a downloadId is not passed in', () => {
+    test('ensure that downloads, files, and pauses which are not active are deleted', async () => {
+      const info = {}
+      const database = {
+        clearDownloadHistoryDownloads: jest.fn()
+      }
+
+      await clearDownloadHistory({
+        database,
+        info
+      })
+
+      expect(database.clearDownloadHistoryDownloads).toHaveBeenCalledTimes(1)
+      // `clearDownloadHistoryDownloads` is called with no arguments
+      expect(database.clearDownloadHistoryDownloads).toHaveBeenCalledWith()
+    })
+  })
+
+  describe('when a downloadId is passed in', () => {
+    test('ensure only the downloads, files, and pauses associated to the downloadId are deleted', async () => {
+      const info = {
+        downloadId: 'mock-download-id'
+      }
+      const database = {
+        clearDownloadHistoryDownloads: jest.fn()
+      }
+
+      await clearDownloadHistory({
+        database,
+        info
+      })
+
+      expect(database.clearDownloadHistoryDownloads).toHaveBeenCalledTimes(1)
+      expect(database.clearDownloadHistoryDownloads).toHaveBeenCalledWith('mock-download-id')
+    })
+  })
+})

--- a/src/main/eventHandlers/__tests__/clearDownloadHistory.test.js
+++ b/src/main/eventHandlers/__tests__/clearDownloadHistory.test.js
@@ -14,8 +14,8 @@ describe('clearDownloadHistory', () => {
       })
 
       expect(database.clearDownloadHistoryDownloads).toHaveBeenCalledTimes(1)
-      // `clearDownloadHistoryDownloads` is called with no arguments
-      expect(database.clearDownloadHistoryDownloads).toHaveBeenCalledWith()
+
+      expect(database.clearDownloadHistoryDownloads).toHaveBeenCalledWith(undefined)
     })
   })
 

--- a/src/main/eventHandlers/clearDownloadHistory.ts
+++ b/src/main/eventHandlers/clearDownloadHistory.ts
@@ -10,10 +10,7 @@ const clearDownloadHistory = async ({
   database,
   info
 }) => {
-  // TODO we should be able to clear individual items from the download history with a button to the actions bar
-  console.log('🚀 ~ file: clearDownloadHistory.ts:14 ~ info:', info)
   const { downloadId = '' } = info
-  console.log('🚀 ~ file: clearDownloadHistory.ts:14 ~ downloadId:', downloadId)
 
   if (downloadId.length > 0) {
     database.clearDownloadHistoryDownloads(downloadId)

--- a/src/main/eventHandlers/clearDownloadHistory.ts
+++ b/src/main/eventHandlers/clearDownloadHistory.ts
@@ -1,0 +1,28 @@
+// @ts-nocheck
+
+/**
+ * Removes downloads in the download history from the database
+ * @param {Object} params
+ * @param {Object} params.database `EddDatabase` instance
+ * @param {Object} params.info `info` parameter from ipc message
+ */
+const clearDownloadHistory = async ({
+  database,
+  info
+}) => {
+  // TODO we should be able to clear individual items from the download history with a button to the actions bar
+  console.log('🚀 ~ file: clearDownloadHistory.ts:14 ~ info:', info)
+  const { downloadId = '' } = info
+  console.log('🚀 ~ file: clearDownloadHistory.ts:14 ~ downloadId:', downloadId)
+
+  if (downloadId.length > 0) {
+    database.clearDownloadHistoryDownloads(downloadId)
+
+    return
+  }
+
+  // Clear all the downloads in the history
+  await database.clearDownloadHistoryDownloads()
+}
+
+export default clearDownloadHistory

--- a/src/main/eventHandlers/clearDownloadHistory.ts
+++ b/src/main/eventHandlers/clearDownloadHistory.ts
@@ -10,16 +10,10 @@ const clearDownloadHistory = async ({
   database,
   info
 }) => {
-  const { downloadId = '' } = info
+  const { downloadId } = info
 
-  if (downloadId.length > 0) {
-    database.clearDownloadHistoryDownloads(downloadId)
-
-    return
-  }
-
-  // Clear all the downloads in the history
-  await database.clearDownloadHistoryDownloads()
+  // Clear the download(s) in the history
+  await database.clearDownloadHistoryDownloads(downloadId)
 }
 
 export default clearDownloadHistory

--- a/src/main/eventHandlers/deleteDownload.ts
+++ b/src/main/eventHandlers/deleteDownload.ts
@@ -11,7 +11,6 @@ const deleteDownload = async ({
   info
 }) => {
   const { downloadId } = info
-
   if (downloadId) {
     await database.deleteDownloadById(downloadId)
   }

--- a/src/main/eventHandlers/deleteDownload.ts
+++ b/src/main/eventHandlers/deleteDownload.ts
@@ -11,6 +11,7 @@ const deleteDownload = async ({
   info
 }) => {
   const { downloadId } = info
+
   if (downloadId) {
     await database.deleteDownloadById(downloadId)
   }

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -18,7 +18,7 @@ contextBridge.exposeInMainWorld('electronApi', {
   cancelDownloadItem: (data) => ipcRenderer.send('cancelDownloadItem', data),
   cancelErroredDownloadItem: (data) => ipcRenderer.send('cancelErroredDownloadItem', data),
   clearDownload: (data) => ipcRenderer.send('clearDownload', data),
-  clearDownloadHistory: () => ipcRenderer.send('clearDownloadHistory'),
+  clearDownloadHistory: (data) => ipcRenderer.send('clearDownloadHistory', data),
   closeWindow: () => ipcRenderer.send('closeWindow'),
   copyDownloadPath: (data) => ipcRenderer.send('copyDownloadPath', data),
   maximizeWindow: () => ipcRenderer.send('maximizeWindow'),

--- a/src/main/utils/__tests__/setupEventListeners.test.ts
+++ b/src/main/utils/__tests__/setupEventListeners.test.ts
@@ -13,6 +13,7 @@ import beginDownload from '../../eventHandlers/beginDownload'
 import cancelDownloadItem from '../../eventHandlers/cancelDownloadItem'
 import cancelErroredDownloadItem from '../../eventHandlers/cancelErroredDownloadItem'
 import clearDownload from '../../eventHandlers/clearDownload'
+import clearDownloadHistory from '../../eventHandlers/clearDownloadHistory'
 import chooseDownloadLocation from '../../eventHandlers/chooseDownloadLocation'
 import copyDownloadPath from '../../eventHandlers/copyDownloadPath'
 import didFinishLoad from '../../eventHandlers/didFinishLoad'
@@ -44,6 +45,7 @@ jest.mock('../../eventHandlers/beginDownload')
 jest.mock('../../eventHandlers/cancelDownloadItem')
 jest.mock('../../eventHandlers/cancelErroredDownloadItem')
 jest.mock('../../eventHandlers/clearDownload')
+jest.mock('../../eventHandlers/clearDownloadHistory')
 jest.mock('../../eventHandlers/chooseDownloadLocation')
 jest.mock('../../eventHandlers/copyDownloadPath')
 jest.mock('../../eventHandlers/didFinishLoad')
@@ -504,6 +506,25 @@ describe('setupEventListeners', () => {
 
       expect(clearDownload).toHaveBeenCalledTimes(1)
       expect(clearDownload).toHaveBeenCalledWith({
+        database,
+        info
+      })
+    })
+  })
+
+  describe('clearDownloadHistory', () => {
+    test('calls clearDownloadHistory', () => {
+      const {
+        database
+      } = setup()
+
+      const event = {}
+      const info = { mock: 'info' }
+
+      ipcRenderer.send('clearDownloadHistory', event, info)
+
+      expect(clearDownloadHistory).toHaveBeenCalledTimes(1)
+      expect(clearDownloadHistory).toHaveBeenCalledWith({
         database,
         info
       })

--- a/src/main/utils/database/EddDatabase.ts
+++ b/src/main/utils/database/EddDatabase.ts
@@ -132,6 +132,28 @@ class EddDatabase {
   }
 
   /**
+   * Deletes downloads which are on the `downloadHistory` page
+   * @param {String} downloadId ID of download to create.
+   */
+  async clearDownloadHistoryDownloads(downloadId) {
+    if (downloadId) {
+      await this.db('downloads').delete().where({ id: downloadId })
+      await this.db('files').delete().where({ downloadId })
+      await this.db('pauses').delete().where({ id: downloadId })
+
+      return
+    }
+
+    // Pluck documentation: https://knexjs.org/guide/query-builder.html#pluck
+    const inactiveDownloads = await this.db('downloads')
+      .pluck('id')
+      .where({ active: false })
+    await this.db('downloads').delete().whereIn('id', inactiveDownloads)
+    await this.db('files').delete().whereIn('downloadId', inactiveDownloads)
+    await this.db('pauses').delete().whereIn('downloadId', inactiveDownloads)
+  }
+
+  /**
    * Creates a new download.
    * @param {String} downloadId ID of download to create.
    * @param {Object} data The data of the download to be inserted.

--- a/src/main/utils/database/__tests__/EddDatabase.test.ts
+++ b/src/main/utils/database/__tests__/EddDatabase.test.ts
@@ -344,6 +344,81 @@ describe('EddDatabase', () => {
     })
   })
 
+  describe('clearDownloadHistoryDownloads', () => {
+    describe('when a downloadId is provided', () => {
+      test('sets the download to inactive', async () => {
+        dbTracker.on('query', (query, step) => {
+          if (step === 1) {
+            expect(query.sql).toEqual('delete from `downloads` where `id` = ?')
+            expect(query.bindings).toEqual(['mock-download-id'])
+          }
+
+          if (step === 2) {
+            expect(query.sql).toEqual('delete from `files` where `downloadId` = ?')
+            expect(query.bindings).toEqual(['mock-download-id'])
+          }
+
+          if (step === 3) {
+            expect(query.sql).toEqual('delete from `pauses` where `id` = ?')
+            expect(query.bindings).toEqual(['mock-download-id'])
+          }
+
+          // We aren't returning anything from this method, the above assertions are the important part of the test
+          query.response([1])
+        })
+
+        const database = new EddDatabase('./')
+
+        await database.clearDownloadHistoryDownloads('mock-download-id')
+      })
+    })
+
+    describe('when a downloadId is not provided', () => {
+      test('deletes all of the downloads, pauses, and files for inactive downloads', async () => {
+        dbTracker.on('query', (query, step) => {
+          if (step === 1) {
+            expect(query.sql).toEqual('select `id` from `downloads` where `active` = ?')
+            expect(query.bindings).toEqual([
+              false
+            ])
+
+            query.response([
+              {
+                id: 'mock-download-id1'
+              },
+              {
+                id: 'mock-download-id2'
+              }
+            ])
+          }
+          // TODO Do I need to pass the query response on each step?
+
+          if (step === 2) {
+            expect(query.sql).toEqual('delete from `downloads` where `id` in (?, ?)')
+            expect(query.bindings).toEqual(['mock-download-id1', 'mock-download-id2'])
+            query.response([1])
+          }
+
+          if (step === 3) {
+            expect(query.sql).toEqual('delete from `files` where `downloadId` in (?, ?)')
+            expect(query.bindings).toEqual(['mock-download-id1', 'mock-download-id2'])
+            query.response([1])
+          }
+
+          if (step === 4) {
+            expect(query.sql).toEqual('delete from `pauses` where `downloadId` in (?, ?)')
+            expect(query.bindings).toEqual(['mock-download-id1', 'mock-download-id2'])
+            query.response([1])
+          }
+        })
+
+        const database = new EddDatabase('./')
+
+        await database.clearDownloadHistoryDownloads()
+      })
+    })
+  })
+
   describe('createDownload', () => {
     test('creates a new download', async () => {
       dbTracker.on('query', (query) => {

--- a/src/main/utils/database/__tests__/EddDatabase.test.ts
+++ b/src/main/utils/database/__tests__/EddDatabase.test.ts
@@ -346,7 +346,7 @@ describe('EddDatabase', () => {
 
   describe('clearDownloadHistoryDownloads', () => {
     describe('when a downloadId is provided', () => {
-      test('sets the download to inactive', async () => {
+      test('deletes the download, files and pauses', async () => {
         dbTracker.on('query', (query, step) => {
           if (step === 1) {
             expect(query.sql).toEqual('delete from `downloads` where `id` = ?')

--- a/src/main/utils/database/__tests__/EddDatabase.test.ts
+++ b/src/main/utils/database/__tests__/EddDatabase.test.ts
@@ -377,36 +377,29 @@ describe('EddDatabase', () => {
       test('deletes all of the downloads, pauses, and files for inactive downloads', async () => {
         dbTracker.on('query', (query, step) => {
           if (step === 1) {
-            expect(query.sql).toEqual('select `id` from `downloads` where `active` = ?')
+            expect(query.sql).toEqual('delete from `pauses` where `downloadId` in (select `id` from `downloads` where `active` = ?)')
             expect(query.bindings).toEqual([
               false
             ])
 
-            query.response([
-              {
-                id: 'mock-download-id1'
-              },
-              {
-                id: 'mock-download-id2'
-              }
-            ])
+            query.response([1])
           }
 
           if (step === 2) {
-            expect(query.sql).toEqual('delete from `downloads` where `id` in (?, ?)')
-            expect(query.bindings).toEqual(['mock-download-id1', 'mock-download-id2'])
+            expect(query.sql).toEqual('delete from `files` where `downloadId` in (select `id` from `downloads` where `active` = ?)')
+            expect(query.bindings).toEqual([
+              false
+            ])
+
             query.response([1])
           }
 
           if (step === 3) {
-            expect(query.sql).toEqual('delete from `files` where `downloadId` in (?, ?)')
-            expect(query.bindings).toEqual(['mock-download-id1', 'mock-download-id2'])
-            query.response([1])
-          }
+            expect(query.sql).toEqual('delete from `downloads` where `downloads`.`active` = ?')
+            expect(query.bindings).toEqual([
+              false
+            ])
 
-          if (step === 4) {
-            expect(query.sql).toEqual('delete from `pauses` where `downloadId` in (?, ?)')
-            expect(query.bindings).toEqual(['mock-download-id1', 'mock-download-id2'])
             query.response([1])
           }
         })

--- a/src/main/utils/database/__tests__/EddDatabase.test.ts
+++ b/src/main/utils/database/__tests__/EddDatabase.test.ts
@@ -391,7 +391,6 @@ describe('EddDatabase', () => {
               }
             ])
           }
-          // TODO Do I need to pass the query response on each step?
 
           if (step === 2) {
             expect(query.sql).toEqual('delete from `downloads` where `id` in (?, ?)')

--- a/src/main/utils/setupEventListeners.ts
+++ b/src/main/utils/setupEventListeners.ts
@@ -13,6 +13,7 @@ import cancelDownloadItem from '../eventHandlers/cancelDownloadItem'
 import cancelErroredDownloadItem from '../eventHandlers/cancelErroredDownloadItem'
 import chooseDownloadLocation from '../eventHandlers/chooseDownloadLocation'
 import clearDownload from '../eventHandlers/clearDownload'
+import clearDownloadHistory from '../eventHandlers/clearDownloadHistory'
 import copyDownloadPath from '../eventHandlers/copyDownloadPath'
 import deleteDownload from '../eventHandlers/deleteDownload'
 import didFinishLoad from '../eventHandlers/didFinishLoad'
@@ -194,6 +195,14 @@ const setupEventListeners = ({
   // Clear a download
   ipcMain.on('clearDownload', async (event, info) => {
     await clearDownload({
+      database,
+      info
+    })
+  })
+
+  // Clear a download form the download history by deleting it
+  ipcMain.on('clearDownloadHistory', async (event, info) => {
+    await clearDownloadHistory({
       database,
       info
     })


### PR DESCRIPTION
# Overview

### What is the feature?

Adding being able to clear items in the download history with the `Clear Download History` and using a button on the `Actions`

### What is the Solution?

Adding database call and supporting function to remove items from the database

### What areas of the application does this impact?

The downloadHistoryPage of the application

List impacted areas.

# Testing

### Reproduction steps

- **Environment for testing:**
- **Collection to test with:**

Add downloads, use the clear downloads button on the downloads page. On the download history page remove the downloads with the clear downloads button. Clear all downloads with the clear download history button on the header

### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have bumped the `version` field in package.json and ran `npm install`
