### PR TITLE
EDD-47: Users should be prompted about submitting their usage metrics

### DIFF
--- a/migrations/20231214205233_add_new_field_to_preferences.js
+++ b/migrations/20231214205233_add_new_field_to_preferences.js
@@ -1,7 +1,0 @@
-exports.up = (knex) => knex.schema.table('preferences', (table) => {
-  table.boolean('allowMetrics').defaultTo(false)
-})
-
-exports.down = (knex) => knex.schema.table('preferences', (table) => {
-  table.dropColumn('allowMetrics')
-})

--- a/migrations/20231214205233_add_new_field_to_preferences.js
+++ b/migrations/20231214205233_add_new_field_to_preferences.js
@@ -1,0 +1,15 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = (knex) => knex.schema.table('preferences', (table) => {
+  table.boolean('allowMetrics')
+})
+
+/**
+   * @param { import("knex").Knex } knex
+   * @returns { Promise<void> }
+   */
+exports.down = (knex) => knex.schema.table('preferences', (table) => {
+  table.dropColumn('allowMetrics')
+})

--- a/migrations/20231214205233_add_new_field_to_preferences.js
+++ b/migrations/20231214205233_add_new_field_to_preferences.js
@@ -1,5 +1,5 @@
 exports.up = (knex) => knex.schema.table('preferences', (table) => {
-  table.boolean('allowMetrics').defaultTo(null)
+  table.boolean('allowMetrics').defaultTo(false)
 })
 
 exports.down = (knex) => knex.schema.table('preferences', (table) => {

--- a/migrations/20231214205233_add_new_field_to_preferences.js
+++ b/migrations/20231214205233_add_new_field_to_preferences.js
@@ -1,15 +1,7 @@
-/**
- * @param { import("knex").Knex } knex
- * @returns { Promise<void> }
- */
 exports.up = (knex) => knex.schema.table('preferences', (table) => {
-  table.boolean('allowMetrics')
+  table.boolean('allowMetrics').defaultTo(null)
 })
 
-/**
-   * @param { import("knex").Knex } knex
-   * @returns { Promise<void> }
-   */
 exports.down = (knex) => knex.schema.table('preferences', (table) => {
   table.dropColumn('allowMetrics')
 })

--- a/migrations/20231221003323_add_hasMetricsPreferenceBeenSet_column_to_preferences_table.js
+++ b/migrations/20231221003323_add_hasMetricsPreferenceBeenSet_column_to_preferences_table.js
@@ -1,0 +1,7 @@
+exports.up = (knex) => knex.schema.table('preferences', (table) => {
+  table.boolean('hasMetricsPreferenceBeenSet').defaultTo(false)
+})
+
+exports.down = (knex) => knex.schema.table('preferences', (table) => {
+  table.dropColumn('hasMetricsPreferenceBeenSet')
+})

--- a/migrations/20231221182834_add_allow_metrics_columns_to_preferences.js
+++ b/migrations/20231221182834_add_allow_metrics_columns_to_preferences.js
@@ -1,7 +1,9 @@
 exports.up = (knex) => knex.schema.table('preferences', (table) => {
+  table.boolean('allowMetrics').defaultTo(false)
   table.boolean('hasMetricsPreferenceBeenSet').defaultTo(false)
 })
 
 exports.down = (knex) => knex.schema.table('preferences', (table) => {
+  table.dropColumn('allowMetrics')
   table.dropColumn('hasMetricsPreferenceBeenSet')
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "earthdata-download",
-  "version": "0.1.1",
+  "version": "0.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "earthdata-download",
-      "version": "0.1.1",
+      "version": "0.1.3",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "earthdata-download",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Earthdata Download is a cross-platform download manager designed to improve how users download Earth Science data. It accepts lists of files from applications like Earthdata Search (https://search.earthdata.nasa.gov/) and enables clients to offer users a streamlined experience when downloading files from their browser.",
   "repository": "nasa/earthdata-download",
   "homepage": "https://github.com/nasa/earthdata-download#readme",

--- a/src/app/components/Layout/Layout.jsx
+++ b/src/app/components/Layout/Layout.jsx
@@ -172,15 +172,20 @@ const Layout = () => {
     }
 
     setPreferenceFieldValue({
+      field: 'hasMetricsPreferenceBeenSet',
+      value: true
+    })
+
+    setPreferenceFieldValue({
       field: 'allowMetrics',
       value: selection
     })
   }
 
   const isMetricsPreferenceSet = async () => {
-    const metricsPreference = await getPreferenceFieldValue('allowMetrics')
+    const hasMetricsPreferenceBeenSet = await getPreferenceFieldValue('hasMetricsPreferenceBeenSet')
 
-    return metricsPreference === 'Allow' || metricsPreference === 'Opt-Out'
+    return hasMetricsPreferenceBeenSet
   }
 
   const onInitializeDownload = async (event, info) => {
@@ -191,8 +196,8 @@ const Layout = () => {
     } = info
 
     // Displaying Allow Metrics prompt if the user hasn't set a value
-    const metricsPreferenceSet = await isMetricsPreferenceSet()
-    if (!metricsPreferenceSet) {
+    const hasMetricsPreferenceBeenSet = await isMetricsPreferenceSet()
+    if (!hasMetricsPreferenceBeenSet) {
       addToast({
         showCloseButton: false,
         id: 'allow-metrics-id',
@@ -204,7 +209,7 @@ const Layout = () => {
             buttonText: 'Yes',
             buttonProps: {
               Icon: FaCheck,
-              onClick: () => metricsToastResponder('Allow')
+              onClick: () => metricsToastResponder(true)
             }
           },
           {
@@ -212,7 +217,7 @@ const Layout = () => {
             buttonText: 'No',
             buttonProps: {
               Icon: FaBan,
-              onClick: () => metricsToastResponder('Opt-Out')
+              onClick: () => metricsToastResponder(false)
             }
           },
           {

--- a/src/app/components/Layout/Layout.jsx
+++ b/src/app/components/Layout/Layout.jsx
@@ -190,6 +190,43 @@ const Layout = () => {
       shouldUseDefaultLocation
     } = info
 
+    // Displaying Allow Metrics prompt if the user hasn't set a value
+    const metricsPreferenceSet = await isMetricsPreferenceSet()
+    if (!metricsPreferenceSet) {
+      addToast({
+        showCloseButton: false,
+        id: 'allow-metrics-id',
+        message: 'Send Anonymous Usage Data?',
+        variant: 'none',
+        actions: [
+          {
+            altText: 'Allow',
+            buttonText: 'Yes',
+            buttonProps: {
+              Icon: FaCheck,
+              onClick: () => metricsToastResponder('Allow')
+            }
+          },
+          {
+            altText: 'Opt-Out',
+            buttonText: 'No',
+            buttonProps: {
+              Icon: FaBan,
+              onClick: () => metricsToastResponder('Opt-Out')
+            }
+          },
+          {
+            altText: 'Settings',
+            buttonText: 'Settings',
+            buttonProps: {
+              Icon: FaCog,
+              onClick: () => metricsToastResponder('Settings')
+            }
+          }
+        ]
+      })
+    }
+
     setDownloadIds(newDownloadIds)
     setSelectedDownloadLocation(newDownloadLocation)
     setUseDefaultLocation(shouldUseDefaultLocation)
@@ -200,43 +237,6 @@ const Layout = () => {
         downloadLocation: newDownloadLocation,
         makeDefaultDownloadLocation: true
       })
-
-      // Displaying Allow Metrics prompt if the user hasn't set a value
-      const metricsPreferenceSet = await isMetricsPreferenceSet()
-      if (!metricsPreferenceSet) {
-        addToast({
-          showCloseButton: false,
-          id: 'allow-metrics-id',
-          message: 'Send Anonymous Usage Data?',
-          variant: 'none',
-          actions: [
-            {
-              altText: 'Allow',
-              buttonText: 'Yes',
-              buttonProps: {
-                Icon: FaCheck,
-                onClick: () => metricsToastResponder('Allow')
-              }
-            },
-            {
-              altText: 'Opt-Out',
-              buttonText: 'No',
-              buttonProps: {
-                Icon: FaBan,
-                onClick: () => metricsToastResponder('Opt-Out')
-              }
-            },
-            {
-              altText: 'Settings',
-              buttonText: 'Settings',
-              buttonProps: {
-                Icon: FaCog,
-                onClick: () => metricsToastResponder('Settings')
-              }
-            }
-          ]
-        })
-      }
 
       // Display a toast notification if a download is initialized
       // while current page is not Downloads

--- a/src/app/components/Layout/Layout.jsx
+++ b/src/app/components/Layout/Layout.jsx
@@ -205,13 +205,14 @@ const Layout = () => {
       const metricsPreferenceSet = await isMetricsPreferenceSet()
       if (!metricsPreferenceSet) {
         addToast({
+          showCloseButton: false,
           id: 'allow-metrics-id',
-          message: 'Send Anonymous Usage Data',
+          message: 'Send Anonymous Usage Data?',
           variant: 'none',
           actions: [
             {
               altText: 'Allow',
-              buttonText: 'Allow',
+              buttonText: 'Yes',
               buttonProps: {
                 Icon: FaCheck,
                 onClick: () => metricsToastResponder('Allow')
@@ -219,7 +220,7 @@ const Layout = () => {
             },
             {
               altText: 'Opt-Out',
-              buttonText: 'Opt-Out',
+              buttonText: 'No',
               buttonProps: {
                 Icon: FaBan,
                 onClick: () => metricsToastResponder('Opt-Out')

--- a/src/app/components/Layout/__tests__/Layout.test.js
+++ b/src/app/components/Layout/__tests__/Layout.test.js
@@ -113,6 +113,10 @@ const setup = (overrideApiContextValue = {}, toasts = {}) => {
   }
 }
 
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
 describe('Layout component', () => {
   test('renders the downloads page', () => {
     setup()
@@ -179,11 +183,13 @@ describe('Layout component', () => {
 
         getPreferenceFieldValue.mockResolvedValueOnce('Allow')
 
-        waitFor(() => {
+        await waitFor(() => {
           callbacks.initializeDownload({ mock: 'event' }, {
             mock: 'info'
           })
+        })
 
+        await waitFor(() => {
           expect(getPreferenceFieldValue).toHaveBeenCalledTimes(1)
           expect(addToast).toHaveBeenCalledTimes(0)
         })
@@ -196,11 +202,13 @@ describe('Layout component', () => {
 
         getPreferenceFieldValue.mockResolvedValueOnce('Opt-Out')
 
-        waitFor(() => {
+        await waitFor(() => {
           callbacks.initializeDownload({ mock: 'event' }, {
             mock: 'info'
           })
+        })
 
+        await waitFor(() => {
           expect(getPreferenceFieldValue).toHaveBeenCalledTimes(1)
           expect(addToast).toHaveBeenCalledTimes(0)
         })
@@ -217,21 +225,26 @@ describe('Layout component', () => {
 
         getPreferenceFieldValue.mockResolvedValueOnce('mock')
 
-        waitFor(() => {
+        await waitFor(() => {
           callbacks.initializeDownload({ mock: 'event' }, {
             mock: 'info'
           })
+        })
 
-          expect(getPreferenceFieldValue).toHaveBeenCalledTimes(1)
+        await waitFor(() => {
           expect(addToast).toHaveBeenCalledTimes(1)
           expect(addToast).toHaveBeenCalledWith({
+            showCloseButton: false,
+            id: 'allow-metrics-id',
+            message: 'Send Anonymous Usage Data?',
+            variant: 'none',
             actions: [
               {
                 altText: 'Allow',
                 buttonText: 'Yes',
                 buttonProps: {
                   Icon: FaCheck,
-                  onClick: () => expect.any(Function)
+                  onClick: expect.any(Function)
                 }
               },
               {
@@ -239,7 +252,7 @@ describe('Layout component', () => {
                 buttonText: 'No',
                 buttonProps: {
                   Icon: FaBan,
-                  onClick: () => expect.any(Function)
+                  onClick: expect.any(Function)
                 }
               },
               {
@@ -247,13 +260,10 @@ describe('Layout component', () => {
                 buttonText: 'Settings',
                 buttonProps: {
                   Icon: FaCog,
-                  onClick: () => expect.any(Function)
+                  onClick: expect.any(Function)
                 }
               }
-            ],
-            id: 'undo-cancel-downloads',
-            message: 'Download Cancelled',
-            variant: 'none'
+            ]
           })
         })
       })

--- a/src/app/components/Layout/__tests__/Layout.test.js
+++ b/src/app/components/Layout/__tests__/Layout.test.js
@@ -184,7 +184,7 @@ describe('Layout component', () => {
           addToast
         } = setup()
 
-        getPreferenceFieldValue.mockResolvedValueOnce('Allow')
+        getPreferenceFieldValue.mockResolvedValueOnce(1)
 
         await waitFor(() => {
           callbacks.initializeDownload({ mock: 'event' }, {
@@ -203,7 +203,7 @@ describe('Layout component', () => {
       test('addToast is not called', async () => {
         const { callbacks, getPreferenceFieldValue, addToast } = setup()
 
-        getPreferenceFieldValue.mockResolvedValueOnce('Opt-Out')
+        getPreferenceFieldValue.mockResolvedValueOnce(2)
 
         await waitFor(() => {
           callbacks.initializeDownload({ mock: 'event' }, {
@@ -226,7 +226,7 @@ describe('Layout component', () => {
           getPreferenceFieldValue
         } = setup()
 
-        getPreferenceFieldValue.mockResolvedValueOnce('mock')
+        getPreferenceFieldValue.mockResolvedValueOnce(0)
 
         await waitFor(() => {
           callbacks.initializeDownload({ mock: 'event' }, {
@@ -283,7 +283,7 @@ describe('Layout component', () => {
               toasts
             } = setup()
 
-            getPreferenceFieldValue.mockResolvedValueOnce('mock')
+            getPreferenceFieldValue.mockResolvedValueOnce(0)
 
             await waitFor(() => {
               callbacks.initializeDownload({ mock: 'event' }, {
@@ -340,10 +340,10 @@ describe('Layout component', () => {
 
             expect(dismissToast).toBeCalledTimes(1)
             expect(dismissToast).toHaveBeenCalledWith('allow-metrics-id')
-            expect(setPreferenceFieldValue).toBeCalledTimes(1)
-            expect(setPreferenceFieldValue).toHaveBeenCalledWith({
+            expect(setPreferenceFieldValue).toBeCalledTimes(2)
+            expect(setPreferenceFieldValue).toHaveBeenLastCalledWith({
               field: 'allowMetrics',
-              value: 'Allow'
+              value: true
             })
           })
         })
@@ -359,7 +359,7 @@ describe('Layout component', () => {
               toasts
             } = setup()
 
-            getPreferenceFieldValue.mockResolvedValueOnce('mock')
+            getPreferenceFieldValue.mockResolvedValueOnce(0)
 
             await waitFor(() => {
               callbacks.initializeDownload({ mock: 'event' }, {
@@ -416,10 +416,10 @@ describe('Layout component', () => {
 
             expect(dismissToast).toBeCalledTimes(1)
             expect(dismissToast).toHaveBeenCalledWith('allow-metrics-id')
-            expect(setPreferenceFieldValue).toBeCalledTimes(1)
+            expect(setPreferenceFieldValue).toBeCalledTimes(2)
             expect(setPreferenceFieldValue).toHaveBeenCalledWith({
               field: 'allowMetrics',
-              value: 'Opt-Out'
+              value: false
             })
           })
         })
@@ -435,7 +435,7 @@ describe('Layout component', () => {
               toasts
             } = setup()
 
-            getPreferenceFieldValue.mockResolvedValueOnce('mock')
+            getPreferenceFieldValue.mockResolvedValueOnce(0)
 
             await waitFor(() => {
               callbacks.initializeDownload({ mock: 'event' }, {

--- a/src/app/components/Toast/Toast.jsx
+++ b/src/app/components/Toast/Toast.jsx
@@ -57,6 +57,7 @@ const Toast = ({
   dismissToast,
   id,
   message,
+  showCloseButton,
   title,
   variant
 }) => (
@@ -128,24 +129,29 @@ const Toast = ({
           </RadixToast.Action>
         ))
       }
-      <RadixToast.Action asChild altText="Dismiss">
-        <Button
-          className={styles.action}
-          data-testid="toast-close-button"
-          onClick={() => dismissToast(id)}
-          Icon={FaTimes}
-          size="lg"
-          hideLabel
-        >
-          Dismiss
-        </Button>
-      </RadixToast.Action>
+      {
+        showCloseButton && (
+          <RadixToast.Action asChild altText="Dismiss">
+            <Button
+              className={styles.action}
+              data-testid="toast-close-button"
+              onClick={() => dismissToast(id)}
+              Icon={FaTimes}
+              size="lg"
+              hideLabel
+            >
+              Dismiss
+            </Button>
+          </RadixToast.Action>
+        )
+      }
     </div>
   </RadixToast.Root>
 )
 
 Toast.defaultProps = {
   actions: [],
+  showCloseButton: true,
   title: null,
   variant: null
 }
@@ -165,6 +171,7 @@ Toast.propTypes = {
   dismissToast: PropTypes.func.isRequired,
   id: PropTypes.string.isRequired,
   message: PropTypes.string.isRequired,
+  showCloseButton: PropTypes.bool,
   title: PropTypes.string,
   variant: PropTypes.string
 }

--- a/src/app/components/ToastList/ToastList.jsx
+++ b/src/app/components/ToastList/ToastList.jsx
@@ -40,6 +40,7 @@ const ToastList = ({
           actions,
           id,
           message,
+          showCloseButton,
           title,
           variant
         }) => (
@@ -50,6 +51,7 @@ const ToastList = ({
             message={message}
             actions={actions}
             title={title}
+            showCloseButton={showCloseButton}
             variant={variant}
           />
         ))
@@ -73,6 +75,7 @@ ToastList.propTypes = {
       actions: PropTypes.arrayOf(
         PropTypes.shape({})
       ),
+      showCloseButton: PropTypes.bool,
       title: PropTypes.string,
       variant: PropTypes.string
     })

--- a/src/app/dialogs/Settings/Settings.jsx
+++ b/src/app/dialogs/Settings/Settings.jsx
@@ -132,7 +132,7 @@ const Settings = ({
   }, [])
 
   useEffect(() => {
-    const fetchConcurrentDownloads = async () => {
+    const fetchConcurrentDownloadsAndMetricsPreference = async () => {
       const newConcurrentDownloads = await getPreferenceFieldValue('concurrentDownloads')
       const newUsageMetrics = await getPreferenceFieldValue('allowMetrics')
       const hasMetricsPreferenceBeenSet = await getPreferenceFieldValue('hasMetricsPreferenceBeenSet')
@@ -145,12 +145,12 @@ const Settings = ({
       }
     }
 
-    fetchConcurrentDownloads()
+    fetchConcurrentDownloadsAndMetricsPreference()
   }, [])
 
   useEffect(() => {
     // Handle edge case where change is made to the concurrency field but, exits
-    const fetchMetricsPreference = async () => {
+    const updateConcurrentDownloadsPreference = async () => {
       const valueNumeric = parseInt(concurrentDownloads.toString(), 10)
       const currentConcurrentDownloads = await getPreferenceFieldValue('concurrentDownloads')
       if (valueNumeric > 0 && valueNumeric !== currentConcurrentDownloads) {
@@ -162,7 +162,7 @@ const Settings = ({
     }
 
     if (!settingsDialogIsOpen) {
-      fetchMetricsPreference()
+      updateConcurrentDownloadsPreference()
     }
   }, [settingsDialogIsOpen, concurrentDownloads, getPreferenceFieldValue, setPreferenceFieldValue])
 

--- a/src/app/dialogs/Settings/Settings.jsx
+++ b/src/app/dialogs/Settings/Settings.jsx
@@ -54,6 +54,7 @@ const Settings = ({
     getPreferenceFieldValue
   } = useContext(ElectronApiContext)
   const [concurrentDownloads, setConcurrentDownloads] = useState('')
+  const [metricsPreference, setMetricsPreference] = useState('')
 
   const onClearDefaultDownload = () => {
     setPreferenceFieldValue({
@@ -82,6 +83,17 @@ const Settings = ({
     // Allow set if non-decimal value and > 0 allow setting of the text field
     if (valueNumeric > 0 && value.indexOf('.') < 0) {
       setConcurrentDownloads(valueNumeric.toString())
+    }
+  }
+
+  const onChangeAllowMetrics = (event) => {
+    const { value } = event.target
+    if (value !== 'Select Options') {
+      setMetricsPreference(value)
+      setPreferenceFieldValue({
+        field: 'allowMetrics',
+        value
+      })
     }
   }
 
@@ -117,7 +129,10 @@ const Settings = ({
   useEffect(() => {
     const fetchConcurrentDownloads = async () => {
       const newConcurrentDownloads = await getPreferenceFieldValue('concurrentDownloads')
+      const newUsageMetrics = await getPreferenceFieldValue('allowMetrics')
+
       setConcurrentDownloads(newConcurrentDownloads.toString())
+      setMetricsPreference(newUsageMetrics)
     }
 
     fetchConcurrentDownloads()
@@ -224,6 +239,21 @@ const Settings = ({
           value={concurrentDownloads}
           onBlur={onBlurConcurrentDownloads}
         />
+      </FormRow>
+      <FormRow
+        label="Send Usage Metrics"
+        description="Allow us to collect anonymous usage data to help us improve our application."
+      >
+        <select
+          className={styles.sendUsageMetricsForm}
+          id="allow-metrics"
+          value={metricsPreference}
+          onChange={(event) => onChangeAllowMetrics(event)}
+        >
+          <option value="Select Option">Select Option</option>
+          <option value="Allow">Allow</option>
+          <option value="Opt-Out">Opt-Out</option>
+        </select>
       </FormRow>
     </div>
   )

--- a/src/app/dialogs/Settings/Settings.jsx
+++ b/src/app/dialogs/Settings/Settings.jsx
@@ -138,7 +138,7 @@ const Settings = ({
       const hasMetricsPreferenceBeenSet = await getPreferenceFieldValue('hasMetricsPreferenceBeenSet')
 
       setConcurrentDownloads(newConcurrentDownloads.toString())
-      if (hasMetricsPreferenceBeenSet === 0) {
+      if (!hasMetricsPreferenceBeenSet) {
         setMetricsPreference('Select Option')
       } else {
         setMetricsPreference(newUsageMetrics === 1)

--- a/src/app/dialogs/Settings/Settings.jsx
+++ b/src/app/dialogs/Settings/Settings.jsx
@@ -55,7 +55,7 @@ const Settings = ({
   } = useContext(ElectronApiContext)
 
   const [concurrentDownloads, setConcurrentDownloads] = useState('')
-  // const [metricsPreference, setMetricsPreference] = useState('')
+  const [metricsPreference, setMetricsPreference] = useState('')
 
   const onClearDefaultDownload = () => {
     setPreferenceFieldValue({
@@ -93,18 +93,18 @@ const Settings = ({
     // DOMString type by default must convert: https://www.w3.org/TR/DOM-Level-3-Core/core.html#ID-C74D1578
     const numMetricsApproval = parseInt(metricsApproval, 10)
 
-    if (metricsApproval !== 'Select Option') {
-      setPreferenceFieldValue({
-        field: 'allowMetrics',
-        value: numMetricsApproval
-      })
+    setPreferenceFieldValue({
+      field: 'allowMetrics',
+      value: numMetricsApproval
+    })
 
-      // Ensure users won't be prompted by toast after they have chosen a preference
-      setPreferenceFieldValue({
-        field: 'hasMetricsPreferenceBeenSet',
-        value: true
-      })
-    }
+    // Ensure users won't be prompted by toast after they have chosen a preference
+    setPreferenceFieldValue({
+      field: 'hasMetricsPreferenceBeenSet',
+      value: true
+    })
+
+    setMetricsPreference(numMetricsApproval)
   }
 
   // Event occurs when element loses focus, write to preferences.json
@@ -142,14 +142,15 @@ const Settings = ({
       const newConcurrentDownloads = await getPreferenceFieldValue('concurrentDownloads')
       setConcurrentDownloads(newConcurrentDownloads.toString())
 
-      // // Fetch current `allowMetrics`
-      // const currentUsageMetrics = await getPreferenceFieldValue('allowMetrics')
-      // const hasMetricsPreferenceBeenSet = await getPreferenceFieldValue('hasMetricsPreferenceBeenSet')
-      // if (!hasMetricsPreferenceBeenSet) {
-      //   setMetricsPreference('Select Option')
-      // } else {
-      //   setMetricsPreference(currentUsageMetrics)
-      // }
+      // Fetch current `allowMetrics`
+      const currentUsageMetrics = await getPreferenceFieldValue('allowMetrics')
+      const hasMetricsPreferenceBeenSet = await getPreferenceFieldValue('hasMetricsPreferenceBeenSet')
+
+      if (!hasMetricsPreferenceBeenSet) {
+        setMetricsPreference('Select Option')
+      } else {
+        setMetricsPreference(currentUsageMetrics)
+      }
     }
 
     fetchCurrentSettings()
@@ -174,7 +175,6 @@ const Settings = ({
     }
   }, [settingsDialogIsOpen])
 
-  // Todo I think we can remove those extra ones
   const downloadLocationInputClassNames = classNames([
     'input',
     styles.downloadLocationInputWrapper
@@ -272,7 +272,8 @@ const Settings = ({
           aria-label="Send Usage Metrics"
           className={styles.sendUsageMetricsForm}
           id="allow-metrics"
-          onChange={(event) => onChangeAllowMetrics(event)}
+          onChange={onChangeAllowMetrics}
+          value={metricsPreference}
         >
           <option hidden value="Select Option">Select Option</option>
           <option value={1}>Yes</option>
@@ -282,7 +283,6 @@ const Settings = ({
     </div>
   )
 }
-// Todo display Select Options if the value has not been set already
 
 Settings.defaultProps = {
   defaultDownloadLocation: ''

--- a/src/app/dialogs/Settings/Settings.jsx
+++ b/src/app/dialogs/Settings/Settings.jsx
@@ -88,7 +88,7 @@ const Settings = ({
 
   const onChangeAllowMetrics = (event) => {
     const { value } = event.target
-    if (value !== 'Select Options') {
+    if (value !== 'Select Option') {
       setMetricsPreference(value)
       setPreferenceFieldValue({
         field: 'allowMetrics',

--- a/src/app/dialogs/Settings/Settings.jsx
+++ b/src/app/dialogs/Settings/Settings.jsx
@@ -132,7 +132,7 @@ const Settings = ({
       const newUsageMetrics = await getPreferenceFieldValue('allowMetrics')
 
       setConcurrentDownloads(newConcurrentDownloads.toString())
-      setMetricsPreference(newUsageMetrics)
+      setMetricsPreference(newUsageMetrics || '')
     }
 
     fetchConcurrentDownloads()

--- a/src/app/dialogs/Settings/Settings.jsx
+++ b/src/app/dialogs/Settings/Settings.jsx
@@ -252,8 +252,8 @@ const Settings = ({
           onChange={(event) => onChangeAllowMetrics(event)}
         >
           <option value="Select Option">Select Option</option>
-          <option value="Allow">Allow</option>
-          <option value="Opt-Out">Opt-Out</option>
+          <option value="Allow">Yes</option>
+          <option value="Opt-Out">No</option>
         </select>
       </FormRow>
     </div>

--- a/src/app/dialogs/Settings/Settings.jsx
+++ b/src/app/dialogs/Settings/Settings.jsx
@@ -71,6 +71,11 @@ const Settings = ({
   }
 
   const onChangeConcurrentDownloads = (event) => {
+    setPreferenceFieldValue({
+      field: 'hasMetricsPreferenceBeenSet',
+      value: false
+    })
+
     const { value } = event.target
 
     // If value is non numerical and can't be parsed as an integer return 0

--- a/src/app/dialogs/Settings/Settings.jsx
+++ b/src/app/dialogs/Settings/Settings.jsx
@@ -71,11 +71,6 @@ const Settings = ({
   }
 
   const onChangeConcurrentDownloads = (event) => {
-    setPreferenceFieldValue({
-      field: 'hasMetricsPreferenceBeenSet',
-      value: false
-    })
-
     const { value } = event.target
 
     // If value is non numerical and can't be parsed as an integer return 0

--- a/src/app/dialogs/Settings/Settings.jsx
+++ b/src/app/dialogs/Settings/Settings.jsx
@@ -245,6 +245,7 @@ const Settings = ({
         description="Allow us to collect anonymous usage data to help us improve our application."
       >
         <select
+          aria-label="Send Usage Metrics"
           className={styles.sendUsageMetricsForm}
           id="allow-metrics"
           value={metricsPreference}

--- a/src/app/dialogs/Settings/Settings.module.scss
+++ b/src/app/dialogs/Settings/Settings.module.scss
@@ -56,6 +56,14 @@
   color: var(--color__black--500);
 }
 
+.sendUsageMetricsForm {
+  min-width: 0;
+  flex-shrink: 1;
+  border-radius: 0.25rem;
+  font-size: 1.1em;
+  padding: 5px 5px;
+}
+
 .settingsClearDefaultDownload {
   width: 20%;
   color: var(--color__text--dark);

--- a/src/app/dialogs/Settings/Settings.module.scss
+++ b/src/app/dialogs/Settings/Settings.module.scss
@@ -60,8 +60,11 @@
   min-width: 0;
   flex-shrink: 1;
   padding: 5px;
+  border-color: var(--color__black--300);
   border-radius: 0.25rem;
-  font-size: 1.1em;
+  background-color: var(--color__black--050);
+  color: var(--color__text--dark);
+  font-size: 1rem;
 }
 
 .settingsClearDefaultDownload {

--- a/src/app/dialogs/Settings/Settings.module.scss
+++ b/src/app/dialogs/Settings/Settings.module.scss
@@ -61,7 +61,7 @@
   flex-shrink: 1;
   border-radius: 0.25rem;
   font-size: 1.1em;
-  padding: 5px 5px;
+  padding: 5px;
 }
 
 .settingsClearDefaultDownload {

--- a/src/app/dialogs/Settings/Settings.module.scss
+++ b/src/app/dialogs/Settings/Settings.module.scss
@@ -59,9 +59,9 @@
 .sendUsageMetricsForm {
   min-width: 0;
   flex-shrink: 1;
+  padding: 5px;
   border-radius: 0.25rem;
   font-size: 1.1em;
-  padding: 5px;
 }
 
 .settingsClearDefaultDownload {

--- a/src/app/dialogs/Settings/__tests__/Settings.test.js
+++ b/src/app/dialogs/Settings/__tests__/Settings.test.js
@@ -192,6 +192,35 @@ describe('Settings dialog', () => {
     })
   })
 
+  test('Changing metrics preferences calls setPreferenceFieldValue', async () => {
+    const user = userEvent.setup()
+    const hasActiveDownloads = false
+    const settingsDialogIsOpen = true
+
+    const getPreferenceFieldValue = jest.fn().mockImplementation((field) => {
+      if (field === 'concurrentDownloads') return 5
+      if (field === 'allowMetrics') return 'Select Option'
+
+      return null
+    })
+
+    const { setPreferenceFieldValue } = setup(
+      hasActiveDownloads,
+      settingsDialogIsOpen,
+      getPreferenceFieldValue
+    )
+
+    const metricsSelect = screen.getByLabelText('Send Usage Metrics', { exact: false })
+    await user.selectOptions(metricsSelect, 'Allow')
+
+    await waitFor(() => {
+      expect(setPreferenceFieldValue).toHaveBeenCalledWith({
+        field: 'allowMetrics',
+        value: 'Allow'
+      })
+    })
+  })
+
   test('Changing the concurrency field and then closing dialog still causes change to store', async () => {
     const setDownloadLocation = jest.fn()
     const setPreferenceFieldValue = jest.fn()

--- a/src/app/dialogs/Settings/__tests__/Settings.test.js
+++ b/src/app/dialogs/Settings/__tests__/Settings.test.js
@@ -211,12 +211,12 @@ describe('Settings dialog', () => {
     )
 
     const metricsSelect = screen.getByLabelText('Send Usage Metrics', { exact: false })
-    await user.selectOptions(metricsSelect, 'Allow')
+    await user.selectOptions(metricsSelect, 'true')
 
     await waitFor(() => {
       expect(setPreferenceFieldValue).toHaveBeenCalledWith({
         field: 'allowMetrics',
-        value: 'Allow'
+        value: true
       })
     })
   })

--- a/src/app/dialogs/Settings/__tests__/Settings.test.js
+++ b/src/app/dialogs/Settings/__tests__/Settings.test.js
@@ -211,11 +211,16 @@ describe('Settings dialog', () => {
     )
 
     const metricsSelect = screen.getByLabelText('Send Usage Metrics', { exact: false })
-    await user.selectOptions(metricsSelect, 'true')
+    await user.selectOptions(metricsSelect, 'Yes')
 
     await waitFor(() => {
       expect(setPreferenceFieldValue).toHaveBeenCalledWith({
         field: 'allowMetrics',
+        value: 1
+      })
+
+      expect(setPreferenceFieldValue).toHaveBeenCalledWith({
+        field: 'hasMetricsPreferenceBeenSet',
         value: true
       })
     })

--- a/src/app/hooks/useToasts.js
+++ b/src/app/hooks/useToasts.js
@@ -4,7 +4,6 @@ import { initialState, toastsReducer } from '../reducers/toastsReducer'
 
 const useToasts = () => {
   const [toasts, toastsDispatch] = useReducer(toastsReducer, initialState)
-
   /**
    * Add a new toast
    */
@@ -13,6 +12,7 @@ const useToasts = () => {
     id,
     message,
     numberErrors,
+    showCloseButton,
     title,
     variant
   }) => {
@@ -23,6 +23,7 @@ const useToasts = () => {
         id,
         message,
         numberErrors,
+        showCloseButton,
         title,
         variant
       }

--- a/src/main/eventHandlers/__tests__/cancelDownloadItem.test.ts
+++ b/src/main/eventHandlers/__tests__/cancelDownloadItem.test.ts
@@ -41,7 +41,7 @@ describe('cancelDownloadItem', () => {
       })
 
       expect(metricsLogger).toHaveBeenCalledTimes(1)
-      expect(metricsLogger).toHaveBeenCalledWith({
+      expect(metricsLogger).toHaveBeenCalledWith(database, {
         eventType: 'DownloadItemCancel',
         data: {
           downloadId: 'mock-download-id'
@@ -91,7 +91,7 @@ describe('cancelDownloadItem', () => {
       })
 
       expect(metricsLogger).toHaveBeenCalledTimes(1)
-      expect(metricsLogger).toHaveBeenCalledWith({
+      expect(metricsLogger).toHaveBeenCalledWith(database, {
         eventType: 'DownloadCancel',
         data: {
           downloadIds: ['mock-download-id'],
@@ -149,7 +149,7 @@ describe('cancelDownloadItem', () => {
       })
 
       expect(metricsLogger).toHaveBeenCalledTimes(1)
-      expect(metricsLogger).toHaveBeenCalledWith({
+      expect(metricsLogger).toHaveBeenCalledWith(database, {
         eventType: 'DownloadCancel',
         data: {
           downloadIds: [123, 456],

--- a/src/main/eventHandlers/__tests__/openUrl.test.ts
+++ b/src/main/eventHandlers/__tests__/openUrl.test.ts
@@ -62,7 +62,7 @@ describe('openUrl', () => {
       )
 
       expect(metricsLogger).toHaveBeenCalledTimes(1)
-      expect(metricsLogger).toHaveBeenCalledWith({
+      expect(metricsLogger).toHaveBeenCalledWith(database, {
         eventType: 'OpenUrl',
         data: {
           clientId: 'eed-edsc-dev-serverless-client',
@@ -108,7 +108,7 @@ describe('openUrl', () => {
       )
 
       expect(metricsLogger).toHaveBeenCalledTimes(1)
-      expect(metricsLogger).toHaveBeenCalledWith({
+      expect(metricsLogger).toHaveBeenCalledWith(database, {
         eventType: 'OpenUrl',
         data: {
           clientId: null,
@@ -154,7 +154,7 @@ describe('openUrl', () => {
       )
 
       expect(metricsLogger).toHaveBeenCalledTimes(1)
-      expect(metricsLogger).toHaveBeenCalledWith({
+      expect(metricsLogger).toHaveBeenCalledWith(database, {
         eventType: 'OpenUrl',
         data: {
           clientId: 'eed-edsc-dev-serverless-client',

--- a/src/main/eventHandlers/__tests__/pauseDownloadItem.test.ts
+++ b/src/main/eventHandlers/__tests__/pauseDownloadItem.test.ts
@@ -85,7 +85,7 @@ describe('pauseDownloadItem', () => {
       })
 
       expect(metricsLogger).toHaveBeenCalledTimes(1)
-      expect(metricsLogger).toHaveBeenCalledWith({
+      expect(metricsLogger).toHaveBeenCalledWith(database, {
         eventType: 'DownloadPause',
         data: {
           downloadCount: 1,
@@ -134,7 +134,7 @@ describe('pauseDownloadItem', () => {
       })
 
       expect(metricsLogger).toHaveBeenCalledTimes(1)
-      expect(metricsLogger).toHaveBeenCalledWith({
+      expect(metricsLogger).toHaveBeenCalledWith(database, {
         eventType: 'DownloadPause',
         data: {
           downloadIds: ['mock-download-id-1', 'mock-download-id-2']

--- a/src/main/eventHandlers/__tests__/restartDownload.test.ts
+++ b/src/main/eventHandlers/__tests__/restartDownload.test.ts
@@ -60,7 +60,7 @@ describe('restartDownload', () => {
       })
 
       expect(metricsLogger).toHaveBeenCalledTimes(1)
-      expect(metricsLogger).toHaveBeenCalledWith({
+      expect(metricsLogger).toHaveBeenCalledWith(database, {
         eventType: 'DownloadRestart',
         data: {
           downloadId: 'mock-download-id',
@@ -156,7 +156,7 @@ describe('restartDownload', () => {
       })
 
       expect(metricsLogger).toHaveBeenCalledTimes(1)
-      expect(metricsLogger).toHaveBeenCalledWith({
+      expect(metricsLogger).toHaveBeenCalledWith(database, {
         eventType: 'DownloadRestart',
         data: {
           downloadId: 'mock-download-id',
@@ -249,7 +249,7 @@ describe('restartDownload', () => {
       })
 
       expect(metricsLogger).toHaveBeenCalledTimes(1)
-      expect(metricsLogger).toHaveBeenCalledWith({
+      expect(metricsLogger).toHaveBeenCalledWith(database, {
         eventType: 'DownloadRestart',
         data: {
           downloadId: 'mock-download-id',

--- a/src/main/eventHandlers/__tests__/resumeDownloadItem.test.ts
+++ b/src/main/eventHandlers/__tests__/resumeDownloadItem.test.ts
@@ -113,7 +113,7 @@ describe('resumeDownloadItem', () => {
         })
 
         expect(metricsLogger).toHaveBeenCalledTimes(1)
-        expect(metricsLogger).toHaveBeenCalledWith({
+        expect(metricsLogger).toHaveBeenCalledWith(database, {
           eventType: 'DownloadResume',
           data: {
             downloadIds: ['mock-download-id'],
@@ -179,7 +179,7 @@ describe('resumeDownloadItem', () => {
         })
 
         expect(metricsLogger).toHaveBeenCalledTimes(1)
-        expect(metricsLogger).toHaveBeenCalledWith({
+        expect(metricsLogger).toHaveBeenCalledWith(database, {
           eventType: 'DownloadResume',
           data: {
             downloadIds: ['mock-download-id'],
@@ -247,7 +247,7 @@ describe('resumeDownloadItem', () => {
       })
 
       expect(metricsLogger).toHaveBeenCalledTimes(1)
-      expect(metricsLogger).toHaveBeenCalledWith({
+      expect(metricsLogger).toHaveBeenCalledWith(database, {
         eventType: 'DownloadResume',
         data: {
           downloadIds: ['download1', 'download2', 'download3'],

--- a/src/main/eventHandlers/__tests__/sendToEula.test.ts
+++ b/src/main/eventHandlers/__tests__/sendToEula.test.ts
@@ -45,7 +45,7 @@ describe('sendToEula', () => {
     })
 
     expect(metricsLogger).toHaveBeenCalledTimes(1)
-    expect(metricsLogger).toHaveBeenCalledWith({
+    expect(metricsLogger).toHaveBeenCalledWith(database, {
       eventType: 'SentToEula',
       data: {
         downloadId: 'downloadID'
@@ -99,7 +99,7 @@ describe('sendToEula', () => {
       })
 
       expect(metricsLogger).toHaveBeenCalledTimes(1)
-      expect(metricsLogger).toHaveBeenCalledWith({
+      expect(metricsLogger).toHaveBeenCalledWith(database, {
         eventType: 'SentToEula',
         data: {
           downloadId: 'downloadID'
@@ -202,7 +202,7 @@ describe('sendToEula', () => {
       })
 
       expect(metricsLogger).toHaveBeenCalledTimes(1)
-      expect(metricsLogger).toHaveBeenCalledWith({
+      expect(metricsLogger).toHaveBeenCalledWith(database, {
         eventType: 'SentToEula',
         data: {
           downloadId: 'downloadID'

--- a/src/main/eventHandlers/__tests__/sendToLogin.test.ts
+++ b/src/main/eventHandlers/__tests__/sendToLogin.test.ts
@@ -44,7 +44,7 @@ describe('sendToLogin', () => {
     })
 
     expect(metricsLogger).toHaveBeenCalledTimes(1)
-    expect(metricsLogger).toHaveBeenCalledWith({
+    expect(metricsLogger).toHaveBeenCalledWith(database, {
       eventType: 'SentToEdl',
       data: {
         downloadId: 'downloadID'
@@ -97,7 +97,7 @@ describe('sendToLogin', () => {
       })
 
       expect(metricsLogger).toHaveBeenCalledTimes(1)
-      expect(metricsLogger).toHaveBeenCalledWith({
+      expect(metricsLogger).toHaveBeenCalledWith(database, {
         eventType: 'SentToEdl',
         data: {
           downloadId: 'downloadID'
@@ -198,7 +198,7 @@ describe('sendToLogin', () => {
       })
 
       expect(metricsLogger).toHaveBeenCalledTimes(1)
-      expect(metricsLogger).toHaveBeenCalledWith({
+      expect(metricsLogger).toHaveBeenCalledWith(database, {
         eventType: 'SentToEdl',
         data: {
           downloadId: 'downloadID'

--- a/src/main/eventHandlers/__tests__/setPreferenceFieldValue.test.ts
+++ b/src/main/eventHandlers/__tests__/setPreferenceFieldValue.test.ts
@@ -24,7 +24,7 @@ describe('set a field in the preferences', () => {
     })
 
     expect(metricsLogger).toHaveBeenCalledTimes(1)
-    expect(metricsLogger).toHaveBeenCalledWith({
+    expect(metricsLogger).toHaveBeenCalledWith(database, {
       eventType: 'NewConcurrentDownloadsLimit',
       data: {
         newConcurrentDownloads: '2'
@@ -50,7 +50,7 @@ describe('set a field in the preferences', () => {
     })
 
     expect(metricsLogger).toHaveBeenCalledTimes(1)
-    expect(metricsLogger).toHaveBeenCalledWith({
+    expect(metricsLogger).toHaveBeenCalledWith(database, {
       eventType: 'NewDefaultDownloadLocation'
     })
 

--- a/src/main/eventHandlers/cancelDownloadItem.ts
+++ b/src/main/eventHandlers/cancelDownloadItem.ts
@@ -40,7 +40,7 @@ const cancelDownloadItem = async ({
       downloadId
     })
 
-    metricsLogger({
+    metricsLogger(database, {
       eventType: 'DownloadItemCancel',
       data: {
         downloadId: downloadIdForMetrics(downloadId)
@@ -66,7 +66,7 @@ const cancelDownloadItem = async ({
 
     await database.endPause(downloadId)
 
-    metricsLogger({
+    metricsLogger(database, {
       eventType: 'DownloadCancel',
       data: {
         downloadIds: [downloadIdForMetrics(downloadId)],
@@ -95,7 +95,7 @@ const cancelDownloadItem = async ({
       await database.endPause(id)
     }))
 
-    metricsLogger({
+    metricsLogger(database, {
       eventType: 'DownloadCancel',
       data: {
         downloadIds: cancelledDownloadIds,

--- a/src/main/eventHandlers/openUrl.ts
+++ b/src/main/eventHandlers/openUrl.ts
@@ -62,7 +62,7 @@ const openUrl = async ({
       state: downloadStates.pending
     })
 
-    metricsLogger({
+    metricsLogger(database, {
       eventType: 'OpenUrl',
       data: {
         clientId,

--- a/src/main/eventHandlers/pauseDownloadItem.ts
+++ b/src/main/eventHandlers/pauseDownloadItem.ts
@@ -38,7 +38,7 @@ const pauseDownloadItem = async ({
       state: downloadStates.paused
     })
 
-    metricsLogger({
+    metricsLogger(database, {
       eventType: 'DownloadPause',
       data: {
         downloadIds: [downloadIdForMetrics(downloadId)],
@@ -58,7 +58,7 @@ const pauseDownloadItem = async ({
     })
 
     const metricIds = pauseResponse.pausedIds.map(downloadIdForMetrics)
-    metricsLogger({
+    metricsLogger(database, {
       eventType: 'DownloadPause',
       data: {
         downloadIds: metricIds

--- a/src/main/eventHandlers/restartDownload.ts
+++ b/src/main/eventHandlers/restartDownload.ts
@@ -28,7 +28,7 @@ const restartDownload = async ({
   } = info
 
   const report = await database.getDownloadReport(downloadId)
-  metricsLogger({
+  metricsLogger(database, {
     eventType: 'DownloadRestart',
     data: {
       downloadId: downloadIdForMetrics(downloadId),

--- a/src/main/eventHandlers/resumeDownloadItem.ts
+++ b/src/main/eventHandlers/resumeDownloadItem.ts
@@ -37,7 +37,7 @@ const resumeDownloadItem = async ({
   }
 
   if (downloadId && !filename) {
-    metricsLogger({
+    metricsLogger(database, {
       eventType: 'DownloadResume',
       data: {
         downloadIds: [downloadIdForMetrics(downloadId)],
@@ -84,7 +84,7 @@ const resumeDownloadItem = async ({
       downloadIds.push(downloadIdForMetrics(id))
     })
 
-    metricsLogger({
+    metricsLogger(database, {
       eventType: 'DownloadResume',
       data: {
         downloadIds,

--- a/src/main/eventHandlers/sendToEula.ts
+++ b/src/main/eventHandlers/sendToEula.ts
@@ -76,7 +76,7 @@ const sendToEula = async ({
       showDialog: true
     })
 
-    metricsLogger({
+    metricsLogger(database, {
       eventType: 'SentToEula',
       data: {
         downloadId: downloadIdForMetrics(downloadId)

--- a/src/main/eventHandlers/sendToLogin.ts
+++ b/src/main/eventHandlers/sendToLogin.ts
@@ -70,7 +70,7 @@ const sendToLogin = async ({
       showDialog: true
     })
 
-    metricsLogger({
+    metricsLogger(database, {
       eventType: 'SentToEdl',
       data: {
         downloadId: downloadIdForMetrics(downloadId)

--- a/src/main/eventHandlers/setPreferenceFieldValue.ts
+++ b/src/main/eventHandlers/setPreferenceFieldValue.ts
@@ -12,10 +12,9 @@ const setPreferenceFieldValue = async ({
   info
 }) => {
   const { field, value } = info
-
   switch (field) {
     case 'concurrentDownloads':
-      metricsLogger({
+      metricsLogger(database, {
         eventType: 'NewConcurrentDownloadsLimit',
         data: {
           newConcurrentDownloads: value
@@ -25,7 +24,7 @@ const setPreferenceFieldValue = async ({
       break
 
     case 'defaultDownloadLocation':
-      metricsLogger({
+      metricsLogger(database, {
         eventType: 'NewDefaultDownloadLocation'
       })
 

--- a/src/main/eventHandlers/willDownloadEvents/__tests__/finishDownload.test.ts
+++ b/src/main/eventHandlers/willDownloadEvents/__tests__/finishDownload.test.ts
@@ -38,7 +38,7 @@ describe('finishDownload', () => {
     })
 
     expect(metricsLogger).toHaveBeenCalledTimes(1)
-    expect(metricsLogger).toHaveBeenCalledWith({
+    expect(metricsLogger).toHaveBeenCalledWith(database, {
       eventType: 'DownloadComplete',
       data: {
         downloadId: 'mock-download-id',

--- a/src/main/eventHandlers/willDownloadEvents/finishDownload.ts
+++ b/src/main/eventHandlers/willDownloadEvents/finishDownload.ts
@@ -22,8 +22,7 @@ const finishDownload = async ({
     })
 
     const downloadStatistics = await database.getDownloadStatistics(downloadId)
-
-    metricsLogger({
+    metricsLogger(database, {
       eventType: 'DownloadComplete',
       data: {
         downloadId: downloadIdForMetrics(downloadId),

--- a/src/main/utils/__tests__/initializeDownload.test.ts
+++ b/src/main/utils/__tests__/initializeDownload.test.ts
@@ -31,7 +31,7 @@ describe('initializeDownload', () => {
     })
 
     expect(metricsLogger).toHaveBeenCalledTimes(1)
-    expect(metricsLogger).toHaveBeenCalledWith({
+    expect(metricsLogger).toHaveBeenCalledWith(database, {
       eventType: 'DownloadStarted',
       data: {
         downloadIds: ['mockDownloadId']
@@ -71,7 +71,7 @@ describe('initializeDownload', () => {
     })
 
     expect(metricsLogger).toHaveBeenCalledTimes(1)
-    expect(metricsLogger).toHaveBeenCalledWith({
+    expect(metricsLogger).toHaveBeenCalledWith(database, {
       eventType: 'DownloadStarted',
       data: {
         downloadIds: ['mockDownloadId']
@@ -112,7 +112,7 @@ describe('initializeDownload', () => {
     })
 
     expect(metricsLogger).toHaveBeenCalledTimes(1)
-    expect(metricsLogger).toHaveBeenCalledWith({
+    expect(metricsLogger).toHaveBeenCalledWith(database, {
       eventType: 'DownloadStarted',
       data: {
         downloadIds: ['mockDownloadId']

--- a/src/main/utils/__tests__/metricsLogger.test.ts
+++ b/src/main/utils/__tests__/metricsLogger.test.ts
@@ -28,8 +28,6 @@ describe('metricsLogger', () => {
   }
 
   test('should not send any metrics when user hasn\'t opted in', async () => {
-    const expectedBody = JSON.stringify({ params: event })
-
     const database = {
       getNotCompletedFilesCountByDownloadId: jest.fn().mockResolvedValue(1),
       updateDownloadById: jest.fn(),

--- a/src/main/utils/__tests__/metricsLogger.test.ts
+++ b/src/main/utils/__tests__/metricsLogger.test.ts
@@ -27,10 +27,34 @@ describe('metricsLogger', () => {
     }
   }
 
-  test('should send a POST request to the specified logging endpoint', async () => {
+  test('should not send any metrics when user hasn\'t opted in', async () => {
     const expectedBody = JSON.stringify({ params: event })
 
-    await metricsLogger(event)
+    const database = {
+      getNotCompletedFilesCountByDownloadId: jest.fn().mockResolvedValue(1),
+      updateDownloadById: jest.fn(),
+      getPreferencesByField: jest.fn().mockResolvedValue(
+        ''
+      )
+    }
+
+    await metricsLogger(database, event)
+
+    expect(fetch).toHaveBeenCalledTimes(0)
+  })
+
+  test('should send a POST request to the specified logging endpoint when user allows metrics', async () => {
+    const expectedBody = JSON.stringify({ params: event })
+
+    const database = {
+      getNotCompletedFilesCountByDownloadId: jest.fn().mockResolvedValue(1),
+      updateDownloadById: jest.fn(),
+      getPreferencesByField: jest.fn().mockResolvedValue(
+        'Allow'
+      )
+    }
+
+    await metricsLogger(database, event)
 
     expect(fetch).toHaveBeenCalledTimes(1)
     expect(fetch).toHaveBeenCalledWith(
@@ -46,6 +70,14 @@ describe('metricsLogger', () => {
   })
 
   test('should log an error when POST request fails', async () => {
+    const database = {
+      getNotCompletedFilesCountByDownloadId: jest.fn().mockResolvedValue(1),
+      updateDownloadById: jest.fn(),
+      getPreferencesByField: jest.fn().mockResolvedValue(
+        'Allow'
+      )
+    }
+
     const expectedError = new Error('Request failed')
 
     fetch
@@ -55,7 +87,7 @@ describe('metricsLogger', () => {
 
     console.error = jest.fn()
 
-    await metricsLogger(event)
+    await metricsLogger(database, event)
 
     expect(fetch).toHaveBeenCalledTimes(1)
 

--- a/src/main/utils/__tests__/metricsLogger.test.ts
+++ b/src/main/utils/__tests__/metricsLogger.test.ts
@@ -32,7 +32,7 @@ describe('metricsLogger', () => {
       getNotCompletedFilesCountByDownloadId: jest.fn().mockResolvedValue(1),
       updateDownloadById: jest.fn(),
       getPreferencesByField: jest.fn().mockResolvedValue(
-        ''
+        0
       )
     }
 
@@ -48,7 +48,7 @@ describe('metricsLogger', () => {
       getNotCompletedFilesCountByDownloadId: jest.fn().mockResolvedValue(1),
       updateDownloadById: jest.fn(),
       getPreferencesByField: jest.fn().mockResolvedValue(
-        'Allow'
+        1
       )
     }
 
@@ -72,7 +72,7 @@ describe('metricsLogger', () => {
       getNotCompletedFilesCountByDownloadId: jest.fn().mockResolvedValue(1),
       updateDownloadById: jest.fn(),
       getPreferencesByField: jest.fn().mockResolvedValue(
-        'Allow'
+        1
       )
     }
 

--- a/src/main/utils/__tests__/windowStateKeeper.test.ts
+++ b/src/main/utils/__tests__/windowStateKeeper.test.ts
@@ -25,7 +25,7 @@ describe('windowStateKeeper', () => {
     }))
 
     expect(metricsLogger).toHaveBeenCalledTimes(1)
-    expect(metricsLogger).toHaveBeenCalledWith({
+    expect(metricsLogger).toHaveBeenCalledWith(database, {
       eventType: 'WindowSizePreferences',
       data: {
         windowStateInfo: {
@@ -62,7 +62,7 @@ describe('windowStateKeeper', () => {
     }))
 
     expect(metricsLogger).toHaveBeenCalledTimes(1)
-    expect(metricsLogger).toHaveBeenCalledWith({
+    expect(metricsLogger).toHaveBeenCalledWith(database, {
       eventType: 'WindowSizePreferences',
       data: {
         windowStateInfo: {
@@ -117,7 +117,7 @@ describe('windowStateKeeper', () => {
         window.send('resize')
 
         expect(metricsLogger).toHaveBeenCalledTimes(1)
-        expect(metricsLogger).toHaveBeenCalledWith({
+        expect(metricsLogger).toHaveBeenCalledWith(database, {
           eventType: 'WindowSizePreferences',
           data: {
             windowStateInfo: {
@@ -175,7 +175,7 @@ describe('windowStateKeeper', () => {
         window.send('resize')
 
         expect(metricsLogger).toHaveBeenCalledTimes(1)
-        expect(metricsLogger).toHaveBeenCalledWith({
+        expect(metricsLogger).toHaveBeenCalledWith(database, {
           eventType: 'WindowSizePreferences',
           data: {
             windowStateInfo: {
@@ -235,7 +235,7 @@ describe('windowStateKeeper', () => {
         window.send('move')
 
         expect(metricsLogger).toHaveBeenCalledTimes(1)
-        expect(metricsLogger).toHaveBeenCalledWith({
+        expect(metricsLogger).toHaveBeenCalledWith(database, {
           eventType: 'WindowSizePreferences',
           data: {
             windowStateInfo: {
@@ -293,7 +293,7 @@ describe('windowStateKeeper', () => {
         window.send('move')
 
         expect(metricsLogger).toHaveBeenCalledTimes(1)
-        expect(metricsLogger).toHaveBeenCalledWith({
+        expect(metricsLogger).toHaveBeenCalledWith(database, {
           eventType: 'WindowSizePreferences',
           data: {
             windowStateInfo: {
@@ -358,7 +358,7 @@ describe('windowStateKeeper', () => {
         })
 
         expect(metricsLogger).toHaveBeenCalledTimes(1)
-        expect(metricsLogger).toHaveBeenCalledWith({
+        expect(metricsLogger).toHaveBeenCalledWith(database, {
           eventType: 'WindowSizePreferences',
           data: {
             windowStateInfo: {
@@ -411,7 +411,7 @@ describe('windowStateKeeper', () => {
         window.send('close')
 
         expect(metricsLogger).toHaveBeenCalledTimes(1)
-        expect(metricsLogger).toHaveBeenCalledWith({
+        expect(metricsLogger).toHaveBeenCalledWith(database, {
           eventType: 'WindowSizePreferences',
           data: {
             windowStateInfo: {

--- a/src/main/utils/database/EddDatabase.ts
+++ b/src/main/utils/database/EddDatabase.ts
@@ -704,8 +704,8 @@ class EddDatabase {
       .sum('totalBytes as totalBytesSum')
       .select(
         this.db.raw('(IFNULL(MAX(timeEnd), UNIXEPOCH() * 1000) - MIN(timeStart)) as totalDownloadTime'),
-        this.db.raw('(SELECT COUNT(id) FROM files WHERE downloadId = ? AND state != "COMPLETED") as incompleteFileCount'),
-        this.db.raw('(SELECT COUNT(id) FROM pauses WHERE downloadId = ? AND fileId IS NULL) as pauseCount')
+        this.db.raw('(SELECT COUNT(id) FROM files WHERE downloadId = ? AND state != \'COMPLETED\') as incompleteFileCount', [downloadId]),
+        this.db.raw('(SELECT COUNT(id) FROM pauses WHERE downloadId = ? AND fileId IS NULL) as pauseCount', [downloadId])
       )
 
     return result

--- a/src/main/utils/database/__tests__/EddDatabase.test.ts
+++ b/src/main/utils/database/__tests__/EddDatabase.test.ts
@@ -93,6 +93,8 @@ describe('EddDatabase', () => {
             name: '20230916012751_add_clear_id_to_downloads.js'
           }, {
             name: '20231214205233_add_new_field_to_preferences.js'
+          }, {
+            name: '20231221003323_add_hasMetricsPreferenceBeenSet_column_to_preferences_table.js'
           }])
         } else if (step === 5) {
           // Query: select `name` from `knex_migrations` order by `id` asc'

--- a/src/main/utils/database/__tests__/EddDatabase.test.ts
+++ b/src/main/utils/database/__tests__/EddDatabase.test.ts
@@ -91,6 +91,8 @@ describe('EddDatabase', () => {
             name: '20230916000205_add_cancel_id_to_files.js'
           }, {
             name: '20230916012751_add_clear_id_to_downloads.js'
+          }, {
+            name: '20231214205233_add_new_field_to_preferences.js'
           }])
         } else if (step === 5) {
           // Query: select `name` from `knex_migrations` order by `id` asc'
@@ -1800,7 +1802,8 @@ describe('EddDatabase', () => {
     test('returns statistics for a completed download', async () => {
       dbTracker.on('query', (query) => {
         expect(query.sql).toEqual(expect.stringContaining('select count(`id`) as `fileCount'))
-        expect(query.bindings).toEqual(['mock-download-id', 1])
+        expect(query.bindings).toContain('mock-download-id')
+        expect(query.bindings).toContain(1)
 
         query.response({
           fileCount: 5,

--- a/src/main/utils/database/__tests__/EddDatabase.test.ts
+++ b/src/main/utils/database/__tests__/EddDatabase.test.ts
@@ -92,9 +92,7 @@ describe('EddDatabase', () => {
           }, {
             name: '20230916012751_add_clear_id_to_downloads.js'
           }, {
-            name: '20231214205233_add_new_field_to_preferences.js'
-          }, {
-            name: '20231221003323_add_hasMetricsPreferenceBeenSet_column_to_preferences_table.js'
+            name: '20231221182834_add_allow_metrics_columns_to_preferences.js'
           }])
         } else if (step === 5) {
           // Query: select `name` from `knex_migrations` order by `id` asc'

--- a/src/main/utils/initializeDownload.ts
+++ b/src/main/utils/initializeDownload.ts
@@ -45,7 +45,7 @@ const initializeDownload = async ({
     })
 
     const metricIds = downloadIds.map(downloadIdForMetrics)
-    metricsLogger({
+    metricsLogger(database, {
       eventType: 'DownloadStarted',
       data: {
         downloadIds: metricIds

--- a/src/main/utils/metricsLogger.ts
+++ b/src/main/utils/metricsLogger.ts
@@ -8,7 +8,12 @@ import config from '../config.json'
  * Dispatches specified events to edd_logger lambda to be logged on CloudWatch
  * @param {Object} event json object to be sent to edd_logger
  */
-const metricsLogger = async (event) => {
+const metricsLogger = async (database, event) => {
+  const allowMetrics = await database.getPreferencesByField('allowMetrics')
+  if (allowMetrics !== 'Allow') {
+    return
+  }
+
   try {
     await fetch(config.logging, {
       method: 'POST',

--- a/src/main/utils/metricsLogger.ts
+++ b/src/main/utils/metricsLogger.ts
@@ -10,7 +10,7 @@ import config from '../config.json'
  */
 const metricsLogger = async (database, event) => {
   const allowMetrics = await database.getPreferencesByField('allowMetrics')
-  if (allowMetrics !== 'Allow') {
+  if (allowMetrics === 0) {
     return
   }
 

--- a/src/main/utils/metricsLogger.ts
+++ b/src/main/utils/metricsLogger.ts
@@ -10,7 +10,7 @@ import config from '../config.json'
  */
 const metricsLogger = async (database, event) => {
   const allowMetrics = await database.getPreferencesByField('allowMetrics')
-  if (allowMetrics === 0) {
+  if (!allowMetrics) {
     return
   }
 

--- a/src/main/utils/windowStateKeeper.ts
+++ b/src/main/utils/windowStateKeeper.ts
@@ -60,7 +60,7 @@ const windowStateKeeper = async (database) => {
     isMaximized: windowState.isMaximized
   }
 
-  metricsLogger({
+  metricsLogger(database, {
     eventType: 'WindowSizePreferences',
     data: {
       windowStateInfo


### PR DESCRIPTION
# Overview

### What is the feature?

We want to collect usage metrics to see how users are using EDD, but we want to prompt them to agree or disagree to have their usage metrics of EDD tracked.

### What is the Solution?

Prompting the user to `Allow` or `Opt-Out` of anonymous usage metrics upon their first download if they have not set a preference in settings.

### What areas of the application does this impact?

Settings

# Testing

### Reproduction steps

1. Download a collection via EDD
2. Verify that the pop-up behaves as expected. (i.e. not displaying if the preference has been set)

### Attachments

<img width="479" alt="Screenshot 2023-12-18 at 1 59 26 AM" src="https://github.com/nasa/earthdata-download/assets/21003704/6e5056a1-2fa1-47c9-bac3-d63d82e4c1c8">


# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have bumped the `version` field in package.json and ran `npm install`
