### PR TITLE
EDD-53: Update the manual download link

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "earthdata-download",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "earthdata-download",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "earthdata-download",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Earthdata Download is a cross-platform download manager designed to improve how users download Earth Science data. It accepts lists of files from applications like Earthdata Search (https://search.earthdata.nasa.gov/) and enables clients to offer users a streamlined experience when downloading files from their browser.",
   "repository": "nasa/earthdata-download",
   "homepage": "https://github.com/nasa/earthdata-download#readme",

--- a/src/app/components/Layout/Layout.jsx
+++ b/src/app/components/Layout/Layout.jsx
@@ -175,7 +175,7 @@ const Layout = () => {
           buttonText: 'Manual Download',
           buttonProps: {
             Icon: FaDownload,
-            onClick: () => window.open('https://github.com/nasa/earthdata-download/releases/latest', '_blank')
+            onClick: () => window.open('https://nasa.github.io/earthdata-download/', '_blank')
           }
         }
       ]

--- a/src/app/components/Layout/__tests__/Layout.test.js
+++ b/src/app/components/Layout/__tests__/Layout.test.js
@@ -543,7 +543,7 @@ describe('Layout component', () => {
 
       onClickFunction()
 
-      expect(window.open).toHaveBeenCalledWith('https://github.com/nasa/earthdata-download/releases/latest', '_blank')
+      expect(window.open).toHaveBeenCalledWith('https://nasa.github.io/earthdata-download/', '_blank')
     })
   })
 


### PR DESCRIPTION
# Overview

### What is the feature?

We should update the page that the user is redirected to when they open the `manual download` link to be the layout page of the application `https://nasa.github.io/earthdata-download/`

### What is the Solution?

Updated the link for the manual download with the correct link. We also need a separate PR that will merge into our https://github.com/nasa/earthdata-download/tree/gh-pages so that we give the correct message if the user is on a Mac (since we intend to release without certs that is)


### What areas of the application does this impact?

Toast message for auto-update in the event of a failure (such as internet being cut)

# Testing

### Reproduction steps

1. Download an older version of EDD
2. Turn off internet connection
3. Open EDD, and verify that auto-update fails and prompts the user to manually download the update

### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have bumped the `version` field in package.json and ran `npm install`
