### PR TITLE
EDD-55: Updating edd_logger to hit prod endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "earthdata-download",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "earthdata-download",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "earthdata-download",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Earthdata Download is a cross-platform download manager designed to improve how users download Earth Science data. It accepts lists of files from applications like Earthdata Search (https://search.earthdata.nasa.gov/) and enables clients to offer users a streamlined experience when downloading files from their browser.",
   "repository": "nasa/earthdata-download",
   "homepage": "https://github.com/nasa/earthdata-download#readme",

--- a/src/main/config.json
+++ b/src/main/config.json
@@ -1,4 +1,4 @@
 {
-  "note": "This endpoint is for EDSC-UAT CloudWatch",
+  "note": "This endpoint is for EDSC CloudWatch",
   "logging": "https://d53njncz5taqi.cloudfront.net/edd_logger"
 }

--- a/src/main/config.json
+++ b/src/main/config.json
@@ -1,4 +1,4 @@
 {
   "note": "This endpoint is for EDSC-UAT CloudWatch",
-  "logging": "https://dycghwhsgr9el.cloudfront.net/edd_logger"
+  "logging": "https://d53njncz5taqi.cloudfront.net/edd_logger"
 }


### PR DESCRIPTION
# Overview

### What is the feature?

Updating the metrics logger for EDD to hit the Prod CloudFront endpoint rather than the UAT one.

### What is the Solution?

Updating the endpoint in `config.json`

### What areas of the application does this impact?

Logging

# Testing

### Reproduction steps

- **Environment for testing:**
- **Collection to test with:**

1. Perform an action that should get logged to CloudWatch (i.e. updating concurrent downloads in settings)
2. Verify the action got logged to edd_logger CloudWatch log group in EDSC Prod AWS.


# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have bumped the `version` field in package.json and ran `npm install`
