### PR TITLE
EDD-61: Create Manual Download Shortcut on 'Interrupted' Downloads

### DIFF
--- a/src/app/components/DownloadItem/DownloadItem.jsx
+++ b/src/app/components/DownloadItem/DownloadItem.jsx
@@ -239,7 +239,7 @@ const DownloadItem = ({
                   actionsList={actionsList}
                 />
                 {
-                  state === downloadStates.interrupted && (
+                  state === downloadStates.interrupted && downloadLinks && (
                     <div className={styles.metaSecondary}>
                       <Button
                         onClick={

--- a/src/app/components/DownloadItem/DownloadItem.jsx
+++ b/src/app/components/DownloadItem/DownloadItem.jsx
@@ -4,6 +4,7 @@ import classNames from 'classnames'
 import MiddleEllipsis from 'react-middle-ellipsis'
 import * as VisuallyHidden from '@radix-ui/react-visually-hidden'
 
+import Button from '../Button/Button'
 import Dropdown from '../Dropdown/Dropdown'
 import Progress from '../Progress/Progress'
 import Tooltip from '../Tooltip/Tooltip'
@@ -23,6 +24,7 @@ import * as styles from './DownloadItem.module.scss'
  * @typedef {Object} DownloadItemProps
  * @property {Array} actionsList A 2-D array of objects detailing action attributes.
  * @property {String} downloadId The ID of the DownloadItem.
+ * @property {String} downloadLinks The download links of the DownloadItem.
  * @property {String} itemName The name of the DownloadItem.
  * @property {Number} percent The download percent of the DownloadItem.
  * @property {Boolean} progressBar Enables or disables the progress bar.
@@ -47,6 +49,7 @@ import * as styles from './DownloadItem.module.scss'
  *   <DownloadItem
  *     actionsList={actionsList}
  *     downloadId={downloadId}
+ *     downloadLinks={downloadLinks}
  *     itemName={filename}
  *     percent={percent}
  *     setCurrentPage={setCurrentPage}
@@ -60,6 +63,7 @@ import * as styles from './DownloadItem.module.scss'
 const DownloadItem = ({
   actionsList,
   downloadId,
+  downloadLinks,
   itemName,
   percent,
   setCurrentPage,
@@ -79,6 +83,23 @@ const DownloadItem = ({
       setSelectedDownloadId(downloadId)
       setCurrentPage(PAGES.fileDownloads)
     }
+  }
+
+  const mapDownloadLinks = (links) => {
+    const linksArray = []
+    links.forEach((link) => {
+      linksArray.push(link)
+    })
+
+    return linksArray
+  }
+
+  const openDownloadLinks = (links) => {
+    const linksArray = mapDownloadLinks(links)
+
+    linksArray.forEach((url) => {
+      window.open(url, '_blank')
+    })
   }
 
   const accessibleEventProps = useAccessibleEvent((event) => {
@@ -217,6 +238,22 @@ const DownloadItem = ({
                   onOpenChange={setMoreActionsOpen}
                   actionsList={actionsList}
                 />
+                {
+                  state === downloadStates.interrupted && (
+                    <div className={styles.metaSecondary}>
+                      <Button
+                        onClick={
+                          (event) => {
+                            openDownloadLinks(downloadLinks[downloadId])
+                            event.stopPropagation()
+                          }
+                        }
+                      >
+                        Manually Download
+                      </Button>
+                    </div>
+                  )
+                }
               </div>
             )
           }
@@ -247,6 +284,7 @@ const DownloadItem = ({
 
 DownloadItem.defaultProps = {
   actionsList: null,
+  downloadLinks: null,
   setCurrentPage: null,
   setSelectedDownloadId: null,
   shouldBeClickable: false,
@@ -272,6 +310,9 @@ DownloadItem.propTypes = {
     )
   ),
   downloadId: PropTypes.string.isRequired,
+  downloadLinks: PropTypes.objectOf(
+    PropTypes.arrayOf(PropTypes.string)
+  ),
   itemName: PropTypes.string.isRequired,
   percent: PropTypes.number.isRequired,
   progressBar: PropTypes.bool,

--- a/src/app/components/DownloadItem/DownloadItem.jsx
+++ b/src/app/components/DownloadItem/DownloadItem.jsx
@@ -85,17 +85,8 @@ const DownloadItem = ({
     }
   }
 
-  const mapDownloadLinks = (links) => {
-    const linksArray = []
-    links.forEach((link) => {
-      linksArray.push(link)
-    })
-
-    return linksArray
-  }
-
   const openDownloadLinks = (links) => {
-    const linksArray = mapDownloadLinks(links)
+    const linksArray = links.map((link) => link)
 
     linksArray.forEach((url) => {
       window.open(url, '_blank')

--- a/src/app/components/DownloadItem/DownloadItem.jsx
+++ b/src/app/components/DownloadItem/DownloadItem.jsx
@@ -86,11 +86,7 @@ const DownloadItem = ({
   }
 
   const openDownloadLinks = (links) => {
-    const linksArray = links.map((link) => link)
-
-    linksArray.forEach((url) => {
-      window.open(url, '_blank')
-    })
+    links.forEach((url) => window.open(url, '_blank'))
   }
 
   const accessibleEventProps = useAccessibleEvent((event) => {

--- a/src/app/components/DownloadItem/__tests__/DownloadItem.test.js
+++ b/src/app/components/DownloadItem/__tests__/DownloadItem.test.js
@@ -585,6 +585,28 @@ describe('DownloadItem component', () => {
     })
   })
 
+  describe('when a download is not in an "interrupted" state', () => {
+    test('the "Manually Download" button is not visible', async () => {
+      const statesWhereButtonShouldNotAppear = [
+        downloadStates.starting,
+        downloadStates.active,
+        downloadStates.paused,
+        downloadStates.completed,
+        downloadStates.error
+      ]
+
+      statesWhereButtonShouldNotAppear.forEach((state) => {
+        setup({
+          state,
+          downloadLinks: { 'download-id': ['https://example.com/file1.zip'] }
+        })
+
+        const manualDownloadButton = screen.queryByText('Manually Download')
+        expect(manualDownloadButton).not.toBeInTheDocument()
+      })
+    })
+  })
+
   describe('when a download is waiting for authentication', () => {
     describe('when the download has not started yet', () => {
       test('displays the correct download information', () => {

--- a/src/app/components/DownloadItem/__tests__/DownloadItem.test.js
+++ b/src/app/components/DownloadItem/__tests__/DownloadItem.test.js
@@ -571,17 +571,17 @@ describe('DownloadItem component', () => {
         downloadLinks: { 'download-id': ['https://example.com/file1.zip'] }
       })
 
-      global.open = jest.fn()
+      global.window.open = jest.fn()
 
       const manualDownloadButton = screen.getByText('Manually Download')
       expect(manualDownloadButton).toBeInTheDocument()
 
       await userEvent.click(manualDownloadButton)
 
-      expect(global.open).toHaveBeenCalledWith('https://example.com/file1.zip', '_blank')
-      expect(global.open).toHaveBeenCalledTimes(1)
+      expect(global.window.open).toHaveBeenCalledWith('https://example.com/file1.zip', '_blank')
+      expect(global.window.open).toHaveBeenCalledTimes(1)
 
-      global.open.mockRestore()
+      global.window.open.mockRestore()
     })
   })
 

--- a/src/app/components/DownloadItem/__tests__/DownloadItem.test.js
+++ b/src/app/components/DownloadItem/__tests__/DownloadItem.test.js
@@ -552,6 +552,39 @@ describe('DownloadItem component', () => {
     })
   })
 
+  describe('when a download is in "interrupted" state', () => {
+    test('displays the "Manually Download" button', async () => {
+      const mockCallback = jest.fn()
+      setup({
+        actionsList: [
+          [
+            {
+              label: 'Manually Download',
+              isActive: true,
+              isPrimary: false,
+              callback: mockCallback
+            }
+          ]
+        ],
+        percent: 0,
+        state: downloadStates.interrupted,
+        downloadLinks: { 'download-id': ['https://example.com/file1.zip'] }
+      })
+
+      global.open = jest.fn()
+
+      const manualDownloadButton = screen.getByText('Manually Download')
+      expect(manualDownloadButton).toBeInTheDocument()
+
+      await userEvent.click(manualDownloadButton)
+
+      expect(global.open).toHaveBeenCalledWith('https://example.com/file1.zip', '_blank')
+      expect(global.open).toHaveBeenCalledTimes(1)
+
+      global.open.mockRestore()
+    })
+  })
+
   describe('when a download is waiting for authentication', () => {
     describe('when the download has not started yet', () => {
       test('displays the correct download information', () => {

--- a/src/app/components/DownloadListItem/DownloadListItem.jsx
+++ b/src/app/components/DownloadListItem/DownloadListItem.jsx
@@ -24,6 +24,7 @@ import useAppContext from '../../hooks/useAppContext'
 /**
  * @typedef {Object} DownloadListItemProps
  * @property {Object} download State of the download item.
+ * @property {Object} downloadLinks Download links for the download item
  * @property {Function} setCurrentPage A function which sets the active page.
  * @property {Function} setSelectedDownloadId A function which sets the setSelectedDownloadId.
  */
@@ -36,6 +37,7 @@ import useAppContext from '../../hooks/useAppContext'
  * return (
  *   <DownloadListItem
  *     download={download}
+ *     downloadLinks={downloadLinks}
  *     setCurrentPage={setCurrentPage}
  *     setSelectedDownloadId={setSelectedDownloadId}
  *   />
@@ -43,6 +45,7 @@ import useAppContext from '../../hooks/useAppContext'
  */
 const DownloadListItem = ({
   download,
+  downloadLinks,
   setCurrentPage,
   setSelectedDownloadId,
   showMoreInfoDialog
@@ -367,6 +370,7 @@ const DownloadListItem = ({
     <DownloadItem
       actionsList={actionsList}
       downloadId={downloadId}
+      downloadLinks={downloadLinks}
       setCurrentPage={setCurrentPage}
       setSelectedDownloadId={setSelectedDownloadId}
       showMoreInfoDialog={showMoreInfoDialog}
@@ -410,6 +414,7 @@ const DownloadListItem = ({
 }
 
 DownloadListItem.defaultProps = {
+  downloadLinks: null,
   setCurrentPage: null,
   setSelectedDownloadId: null
 }
@@ -427,6 +432,9 @@ DownloadListItem.propTypes = {
     }),
     state: PropTypes.string
   }).isRequired,
+  downloadLinks: PropTypes.objectOf(
+    PropTypes.arrayOf(PropTypes.string)
+  ),
   setCurrentPage: PropTypes.func,
   setSelectedDownloadId: PropTypes.func,
   showMoreInfoDialog: PropTypes.func.isRequired

--- a/src/app/components/Layout/Layout.jsx
+++ b/src/app/components/Layout/Layout.jsx
@@ -84,7 +84,6 @@ const Layout = () => {
   const [chooseDownloadLocationIsOpen, setChooseDownloadLocationIsOpen] = useState(false)
   const [currentPage, setCurrentPage] = useState(PAGES.downloads)
   const [downloadIds, setDownloadIds] = useState(null)
-  const [downloadLinks, setDownloadLinks] = useState([])
   const [downloadLinksMap, setDownloadLinksMap] = useState({})
   const [hasActiveDownload, setHasActiveDownload] = useState(false)
   const [isWindowMaximized, setIsWindowMaximized] = useState(false)

--- a/src/app/components/Layout/Layout.jsx
+++ b/src/app/components/Layout/Layout.jsx
@@ -84,6 +84,8 @@ const Layout = () => {
   const [chooseDownloadLocationIsOpen, setChooseDownloadLocationIsOpen] = useState(false)
   const [currentPage, setCurrentPage] = useState(PAGES.downloads)
   const [downloadIds, setDownloadIds] = useState(null)
+  const [downloadLinks, setDownloadLinks] = useState([])
+  const [downloadLinksMap, setDownloadLinksMap] = useState({})
   const [hasActiveDownload, setHasActiveDownload] = useState(false)
   const [isWindowMaximized, setIsWindowMaximized] = useState(false)
   const [moreErrorInfoIsOpen, setMoreErrorInfoIsOpen] = useState()
@@ -212,6 +214,7 @@ const Layout = () => {
     const {
       downloadIds: newDownloadIds,
       downloadLocation: newDownloadLocation,
+      links,
       shouldUseDefaultLocation
     } = info
 
@@ -253,6 +256,9 @@ const Layout = () => {
     }
 
     setDownloadIds(newDownloadIds)
+    const newLinksMap = downloadLinksMap
+    newLinksMap[newDownloadIds] = links
+    setDownloadLinksMap(newLinksMap)
     setSelectedDownloadLocation(newDownloadLocation)
     setUseDefaultLocation(shouldUseDefaultLocation)
     // If shouldUseDefaultLocation is true, start the download(s)
@@ -313,6 +319,7 @@ const Layout = () => {
         setSelectedDownloadId(null)
         setPageComponent(
           <Downloads
+            downloadLinks={downloadLinksMap}
             setSelectedDownloadId={setSelectedDownloadId}
             setCurrentPage={setCurrentPage}
             hasActiveDownload={hasActiveDownload}
@@ -568,6 +575,7 @@ const Layout = () => {
         >
           <InitializeDownload
             downloadIds={downloadIds}
+            downloadLinks={downloadLinks}
             downloadLocation={selectedDownloadLocation}
             setDownloadIds={setDownloadIds}
             onCloseChooseLocationDialog={onCloseChooseLocationDialog}

--- a/src/app/components/Layout/Layout.jsx
+++ b/src/app/components/Layout/Layout.jsx
@@ -574,7 +574,6 @@ const Layout = () => {
         >
           <InitializeDownload
             downloadIds={downloadIds}
-            downloadLinks={downloadLinks}
             downloadLocation={selectedDownloadLocation}
             setDownloadIds={setDownloadIds}
             onCloseChooseLocationDialog={onCloseChooseLocationDialog}

--- a/src/app/components/Layout/Layout.jsx
+++ b/src/app/components/Layout/Layout.jsx
@@ -84,7 +84,7 @@ const Layout = () => {
   const [chooseDownloadLocationIsOpen, setChooseDownloadLocationIsOpen] = useState(false)
   const [currentPage, setCurrentPage] = useState(PAGES.downloads)
   const [downloadIds, setDownloadIds] = useState(null)
-  const [downloadLinksMap, setDownloadLinksMap] = useState({})
+  const [downloadLinks, setDownloadLinks] = useState({})
   const [hasActiveDownload, setHasActiveDownload] = useState(false)
   const [isWindowMaximized, setIsWindowMaximized] = useState(false)
   const [moreErrorInfoIsOpen, setMoreErrorInfoIsOpen] = useState()
@@ -255,9 +255,11 @@ const Layout = () => {
     }
 
     setDownloadIds(newDownloadIds)
-    const newLinksMap = downloadLinksMap
-    newLinksMap[newDownloadIds] = links
-    setDownloadLinksMap(newLinksMap)
+    setDownloadLinks({
+      ...downloadLinks,
+      [newDownloadIds]: links
+    })
+
     setSelectedDownloadLocation(newDownloadLocation)
     setUseDefaultLocation(shouldUseDefaultLocation)
     // If shouldUseDefaultLocation is true, start the download(s)
@@ -318,7 +320,7 @@ const Layout = () => {
         setSelectedDownloadId(null)
         setPageComponent(
           <Downloads
-            downloadLinks={downloadLinksMap}
+            downloadLinks={downloadLinks}
             setSelectedDownloadId={setSelectedDownloadId}
             setCurrentPage={setCurrentPage}
             hasActiveDownload={hasActiveDownload}

--- a/src/app/components/ListPage/ListPageListItem.jsx
+++ b/src/app/components/ListPage/ListPageListItem.jsx
@@ -56,6 +56,7 @@ const ListPageListItem = ({
 
   const {
     download,
+    downloadLinks,
     file,
     setCurrentPage,
     setSelectedDownloadId,
@@ -91,6 +92,7 @@ const ListPageListItem = ({
     <div style={style}>
       <DownloadListItem
         download={download}
+        downloadLinks={downloadLinks}
         setCurrentPage={setCurrentPage}
         setSelectedDownloadId={setSelectedDownloadId}
         showMoreInfoDialog={showMoreInfoDialog}
@@ -105,6 +107,9 @@ ListPageListItem.propTypes = {
   data: PropTypes.arrayOf(
     PropTypes.shape({
       download: PropTypes.shape({}),
+      downloadLinks: PropTypes.objectOf(
+        PropTypes.arrayOf(PropTypes.string)
+      ).isRequired,
       file: PropTypes.shape({}),
       setCurrentPage: PropTypes.func,
       setSelectedDownloadId: PropTypes.func,

--- a/src/app/components/ListPage/ListPageListItem.jsx
+++ b/src/app/components/ListPage/ListPageListItem.jsx
@@ -109,7 +109,7 @@ ListPageListItem.propTypes = {
       download: PropTypes.shape({}),
       downloadLinks: PropTypes.objectOf(
         PropTypes.arrayOf(PropTypes.string)
-      ).isRequired,
+      ),
       file: PropTypes.shape({}),
       setCurrentPage: PropTypes.func,
       setSelectedDownloadId: PropTypes.func,

--- a/src/app/components/ListPage/__tests__/ListPageListItem.test.js
+++ b/src/app/components/ListPage/__tests__/ListPageListItem.test.js
@@ -27,11 +27,13 @@ describe('ListPageListItem', () => {
     test('renders a DownloadListItem', () => {
       const setCurrentPage = jest.fn()
       const setSelectedDownloadId = jest.fn()
+      const downloadLinks = {}
 
       setup({
         data: [{
           type: 'download',
           download: { mock: 'download' },
+          downloadLinks: {},
           setCurrentPage,
           setSelectedDownloadId
         }]
@@ -42,6 +44,7 @@ describe('ListPageListItem', () => {
         download: {
           mock: 'download'
         },
+        downloadLinks,
         setCurrentPage,
         setSelectedDownloadId
       }, {})

--- a/src/app/pages/Downloads/Downloads.jsx
+++ b/src/app/pages/Downloads/Downloads.jsx
@@ -27,6 +27,7 @@ import ListPage from '../../components/ListPage/ListPage'
 
 /**
  * @typedef {Object} DownloadsProps
+ * @property {Function} downloadLinks Download links for each download
  * @property {Function} setCurrentPage A function which sets the active page.
  * @property {Function} setHasActiveDownload A function to set whether a download is active.
  * @property {Function} setSelectedDownloadId A function to set the selectedDownloadId.
@@ -40,6 +41,7 @@ import ListPage from '../../components/ListPage/ListPage'
  *
  * return (
  *   <Downloads
+ *     downloadLinks={downloadLinks}
  *     setCurrentPage={setCurrentPage}
  *     setHasActiveDownload={setHasActiveDownload}
  *     setSelectedDownloadId={setSelectedDownloadId}
@@ -48,6 +50,7 @@ import ListPage from '../../components/ListPage/ListPage'
  * )
  */
 const Downloads = ({
+  downloadLinks,
   setCurrentPage,
   setHasActiveDownload,
   setSelectedDownloadId,
@@ -95,6 +98,7 @@ const Downloads = ({
           ...download,
           numberErrors: errors[downloadId]?.numberErrors
         },
+        downloadLinks,
         setCurrentPage,
         setSelectedDownloadId,
         showMoreInfoDialog,
@@ -214,6 +218,9 @@ const Downloads = ({
 }
 
 Downloads.propTypes = {
+  downloadLinks: PropTypes.objectOf(
+    PropTypes.arrayOf(PropTypes.string)
+  ).isRequired,
   setCurrentPage: PropTypes.func.isRequired,
   setHasActiveDownload: PropTypes.func.isRequired,
   setSelectedDownloadId: PropTypes.func.isRequired,

--- a/src/main/utils/fetchLinks.ts
+++ b/src/main/utils/fetchLinks.ts
@@ -127,6 +127,7 @@ const fetchLinks = async ({
         initializeDownload({
           downloadIds: [downloadId],
           database,
+          links,
           webContents: appWindow.webContents
         })
       }

--- a/src/main/utils/initializeDownload.ts
+++ b/src/main/utils/initializeDownload.ts
@@ -15,6 +15,7 @@ import downloadIdForMetrics from '../utils/downloadIdForMetrics'
 const initializeDownload = async ({
   database,
   downloadIds,
+  links,
   webContents
 }) => {
   if (downloadIds.length > 0) {
@@ -41,6 +42,7 @@ const initializeDownload = async ({
     webContents.send('initializeDownload', {
       downloadIds,
       downloadLocation: location,
+      links,
       shouldUseDefaultLocation: !!defaultDownloadLocation
     })
 


### PR DESCRIPTION
# Overview

### What is the feature?

When a download is interrupted, the user should be able to hover the download and select a 'Manual Download' option.

### What is the Solution?

Display a `Manual Download` button on a `DownloadItem` when the user hovers an interrupted download so they can manually download the files.

### What areas of the application does this impact?

Download View

# Testing

### Reproduction steps

- **Environment for testing:**
- **Collection to test with:**

1. Select a granule (or multiple) from this collection `C2151211533-LAADS` and add them to your project
2. Navigate to project download.
3. Download files via EDD.
4. Verify that the download gets interrupted, and that hovering the `DownloadItem` displays the `Manual Download` button and that clicking it takes you to download all the files via web browser.


# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have bumped the `version` field in package.json and ran `npm install`
