### PR TITLE
EDD-29: Updates download page with windows instructions

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,18 +16,6 @@
       </span>
     </header>
     <section class="primary-download primary-download--macos">
-      <div class="acknowledgement-body">
-        <h3>Attention MacOS users!<br> In order to run Earthdata Download the first time, you need to follow these steps:</h3>
-        <div class="acknowledgement-body--steps-list-container">
-          <ol class="acknowledgement-body--steps-list">
-            <li>Locate the app in the Finder on your Mac.</li>
-            <li>Do not use the Mac Launchpad to locate the app.</li>
-            <li>Control-click the app icon, then choose Open from the <br>shortcut menu. (You may need to repeat this step one time)</li>
-            <li>Click Open.</li>
-          </ol>
-        </div>
-        <p class="acknowledgement-body--italic-text">*This is only required for the first time you run the app.</p>
-      </div>
       <a class="button button--primary primary-download__link" href="%VITE_OS_MACOS_DMG_DOWNLOAD_LINK%" id="macDownloadButton" disabled>
         <span class="primary-download__icon">
           <svg class="button__icon icon" xmlns="http://www.w3.org/2000/svg" height="1em" viewBox="0 0 512 512"
@@ -60,6 +48,15 @@
         <span>
           %VITE_OS_WINDOWS_EXE_DOWNLOAD_SIZE% (.exe)
         </span>
+      </div>
+      <div class="acknowledgement-body container">
+        <h3 class="acknowledgement-body__title">Attention Windows users!</h3>
+        <p class="acknowledgement-body__content">
+          When you open the installer you might see a popup titled "Windows protected your PC". To allow the application to install, click on "More info" and then click "Run anyway" to run the installer.
+        </p>
+        <p class="acknowledgement-body__content">
+          If you don't see "Run anyway", the installer might be blocked. To unblock the installer, right-click on the "Earthdata-Download-x64" file in the File Explorer and select "Properties". On the "General" tab, select the "Unblock" checkbox in the "Security" options. Click the "OK" button save the change. After unblocking the installer, double click on the "Earthdata-Download-x64" to start the installation. Click "More info" in the "Windows protected your PC" popup and click "Run anyway" to run the installer.
+        </p>
       </div>
     </section>
     <section class="primary-download primary-download--linux">

--- a/style.scss
+++ b/style.scss
@@ -65,21 +65,12 @@ a {
   text-align: center;
   font-size: 1.5rem;
 
-  &--steps-list-container {
-    font-size: 1.2rem;
-    display: inline-block;
-    text-align: left;
+  &__title {
+    font-size: 1.5rem;
   }
 
-  &--steps-list {
-    padding-left: 0;
-    list-style-position: inside;
-    margin-left: 0;
-  }
-
-  &--italic-text {
+  &__content {
     font-size: 1rem;
-    font-style: italic;
   }
 }
 


### PR DESCRIPTION
# Overview

### What is the feature?

Updates the download page to include help text for Windows

<img width="1135" alt="Screenshot 2024-07-11 at 3 25 45 PM" src="https://github.com/user-attachments/assets/ebedeba0-dc03-41ce-922b-a5dc35e57ff0">
