### PR TITLE
EDD-71: Adds new trusted values for Earthdata Search

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "earthdata-download",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "earthdata-download",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "earthdata-download",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Earthdata Download is a cross-platform download manager designed to improve how users download Earth Science data. It accepts lists of files from applications like Earthdata Search (https://search.earthdata.nasa.gov/) and enables clients to offer users a streamlined experience when downloading files from their browser.",
   "repository": "nasa/earthdata-download",
   "homepage": "https://github.com/nasa/earthdata-download#readme",

--- a/src/main/trustedSources.json
+++ b/src/main/trustedSources.json
@@ -3,5 +3,10 @@
   "localhost": { "notes": "development" },
   "d53njncz5taqi.cloudfront.net": { "notes": "Corresponds to search.earthdata.nasa.gov" },
   "dycghwhsgr9el.cloudfront.net": { "notes": "Corresponds to search.uat.earthdata.nasa.gov" },
-  "d30czzksj9a4kf.cloudfront.net": { "notes": "Corresponds to search.sit.earthdata.nasa.gov" }
+  "d30czzksj9a4kf.cloudfront.net": { "notes": "Corresponds to search.sit.earthdata.nasa.gov" },
+  "api.search.sit.earthdatacloud.nasa.gov": { "notes": "Corresponds to search.sit.earthdata.nasa.gov" },
+  "api.search.uat.earthdatacloud.nasa.gov": { "notes": "Corresponds to search.uat.earthdata.nasa.gov" },
+  "api.search.earthdatacloud.nasa.gov": { "notes": "Corresponds to search.earthdata.nasa.gov" },
+  "searchprodapi-1167262027.auto.earthdatacloud.nasa.gov": { "notes": "Corresponds to search.earthdata.nasa.gov" },
+  "searchuatapi-2287602643.auto.earthdatacloud.nasa.gov": { "notes": "Corresponds to search.uat.earthdata.nasa.gov" }
 }


### PR DESCRIPTION
# Overview

### What is the feature?

Adds new trusted values for Earthdata Search. These are new values for EDSC's API used when retrieving download links.

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have bumped the `version` field in package.json and ran `npm install`
