### PR TITLE
Add nsidc org trusted sources

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "earthdata-download",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "earthdata-download",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "earthdata-download",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Earthdata Download is a cross-platform download manager designed to improve how users download Earth Science data. It accepts lists of files from applications like Earthdata Search (https://search.earthdata.nasa.gov/) and enables clients to offer users a streamlined experience when downloading files from their browser.",
   "repository": "nasa/earthdata-download",
   "homepage": "https://github.com/nasa/earthdata-download#readme",

--- a/src/main/trustedSources.json
+++ b/src/main/trustedSources.json
@@ -8,5 +8,9 @@
   "api.search.uat.earthdatacloud.nasa.gov": { "notes": "Corresponds to search.uat.earthdata.nasa.gov" },
   "api.search.earthdatacloud.nasa.gov": { "notes": "Corresponds to search.earthdata.nasa.gov" },
   "searchprodapi-1167262027.auto.earthdatacloud.nasa.gov": { "notes": "Corresponds to search.earthdata.nasa.gov" },
-  "searchuatapi-2287602643.auto.earthdatacloud.nasa.gov": { "notes": "Corresponds to search.uat.earthdata.nasa.gov" }
+  "searchuatapi-2287602643.auto.earthdatacloud.nasa.gov": { "notes": "Corresponds to search.uat.earthdata.nasa.gov" },
+  "nsidc.org": { "notes": "Corresponds to NSIDC production" },
+  "integration.nsidc.org": { "notes": "Corresponds to NSIDC integration env" },
+  "staging.nsidc.org": { "notes": "Corresponds to NSIDC staging env" },
+  "qa.nsidc.org": { "notes": "Corresponds to NSIDC QA env" }
 }


### PR DESCRIPTION
# Overview

NSIDC will host the Data Access Tool's backend services at nsidc.org. This PR adds the nsidc.org domains to the trusted sources list.

### What is the feature?

This PR adds the nsidc.org domains to the trusted sources list.

### What is the Solution?

Updated `trustedSources.json`

### What areas of the application does this impact?

Just the list of trusted sources.

# Testing

### Reproduction steps

No new tests.


# Checklist

- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have bumped the `version` field in package.json and ran `npm install`
