### PR TITLE
Make hostname checks case-insensitive in `openUrl`

### DIFF
--- a/src/main/eventHandlers/__tests__/openUrl.test.ts
+++ b/src/main/eventHandlers/__tests__/openUrl.test.ts
@@ -273,18 +273,18 @@ describe('openUrl', () => {
 
 describe('checkHostname', () => {
   test.each(['startDownload', 'startdownload'])('accepts case insensitive startDownload', async (hostname) => {
-    expect(checkHostname(hostname, 'startDownload')).toBe(true);
+    expect(checkHostname(hostname, 'startDownload')).toBe(true)
   })
 
   test.each(['authCallback', 'authcallback'])('accepts case insensitive authCallback', async (hostname) => {
-    expect(checkHostname(hostname, 'authCallback')).toBe(true);
+    expect(checkHostname(hostname, 'authCallback')).toBe(true)
   })
 
   test.each(['eulaCallback', 'eulacallback'])('accepts case insensitive eulaCallback', async (hostname) => {
-    expect(checkHostname(hostname, 'eulaCallback')).toBe(true);
+    expect(checkHostname(hostname, 'eulaCallback')).toBe(true)
   })
 
-  test.each(['foo', 'bar'])('returns false when hostnames do not compare', async (hostname) =>{
-    expect(checkHostname(hostname, 'baz')).toBe(false);
+  test.each(['foo', 'bar'])('returns false when hostnames do not compare', async (hostname) => {
+    expect(checkHostname(hostname, 'baz')).toBe(false)
   })
 })

--- a/src/main/eventHandlers/__tests__/openUrl.test.ts
+++ b/src/main/eventHandlers/__tests__/openUrl.test.ts
@@ -2,7 +2,7 @@
 
 import MockDate from 'mockdate'
 
-import openUrl from '../openUrl'
+import openUrl, { checkHostname } from '../openUrl'
 
 import downloadStates from '../../../app/constants/downloadStates'
 
@@ -268,5 +268,23 @@ describe('openUrl', () => {
         fileId: '1234'
       }))
     })
+  })
+})
+
+describe('checkHostname', () => {
+  test.each(['startDownload', 'startdownload'])('accepts case insensitive startDownload', async (hostname) => {
+    expect(checkHostname(hostname, 'startDownload')).toBe(true);
+  })
+
+  test.each(['authCallback', 'authcallback'])('accepts case insensitive authCallback', async (hostname) => {
+    expect(checkHostname(hostname, 'authCallback')).toBe(true);
+  })
+
+  test.each(['eulaCallback', 'eulacallback'])('accepts case insensitive eulaCallback', async (hostname) => {
+    expect(checkHostname(hostname, 'eulaCallback')).toBe(true);
+  })
+
+  test.each(['foo', 'bar'])('returns false when hostnames do not compare', async (hostname) =>{
+    expect(checkHostname(hostname, 'baz')).toBe(false);
   })
 })

--- a/src/main/eventHandlers/openUrl.ts
+++ b/src/main/eventHandlers/openUrl.ts
@@ -7,6 +7,17 @@ import startPendingDownloads from '../utils/startPendingDownloads'
 
 import downloadStates from '../../app/constants/downloadStates'
 
+
+/**
+ * Check the given hostname against the expected value in a case-insensitive
+ * manner.
+ * @param {String} hostname String representing the hostname from a URL
+ * @param {String} expected String representing the expected hostname
+ */
+export const checkHostname = (hostname: string, expected: string): boolean => {
+  return hostname.toLowerCase() === expected.toLowerCase();
+}
+
 /**
  * Parses `deepLink` for info and fetches download links
  * @param {Object} params
@@ -35,7 +46,7 @@ const openUrl = async ({
   } = url
 
   // Start a new download
-  if (hostname === 'startDownload') {
+  if (checkHostname(hostname, 'startDownload')) {
     const authUrl = searchParams.get('authUrl')
     const downloadIdWithoutTime = searchParams.get('downloadId')
     const eulaRedirectUrl = searchParams.get('eulaRedirectUrl')
@@ -95,7 +106,7 @@ const openUrl = async ({
   }
 
   // User has been authenticated, save the new token and start the download
-  if (hostname === 'authCallback') {
+  if (checkHostname(hostname,'authCallback')) {
     const token = searchParams.get('token')
     const fileId = searchParams.get('fileId')
 
@@ -137,7 +148,7 @@ const openUrl = async ({
   }
 
   // User has accepted a EULA, start the download
-  if (hostname === 'eulaCallback') {
+  if (checkHostname(hostname, 'eulacallback')) {
     const fileId = searchParams.get('fileId')
 
     // Logging out the `deepLink` was tricky to try to remove any tokens in the URL. Instead we are using this

--- a/src/main/eventHandlers/openUrl.ts
+++ b/src/main/eventHandlers/openUrl.ts
@@ -7,16 +7,15 @@ import startPendingDownloads from '../utils/startPendingDownloads'
 
 import downloadStates from '../../app/constants/downloadStates'
 
-
 /**
  * Check the given hostname against the expected value in a case-insensitive
  * manner.
  * @param {String} hostname String representing the hostname from a URL
  * @param {String} expected String representing the expected hostname
  */
-export const checkHostname = (hostname: string, expected: string): boolean => {
-  return hostname.toLowerCase() === expected.toLowerCase();
-}
+export const checkHostname = (hostname: string, expected: string): boolean => (
+  hostname.toLowerCase() === expected.toLowerCase()
+)
 
 /**
  * Parses `deepLink` for info and fetches download links
@@ -106,7 +105,7 @@ const openUrl = async ({
   }
 
   // User has been authenticated, save the new token and start the download
-  if (checkHostname(hostname,'authCallback')) {
+  if (checkHostname(hostname, 'authCallback')) {
     const token = searchParams.get('token')
     const fileId = searchParams.get('fileId')
 


### PR DESCRIPTION
Resolves https://github.com/nasa/earthdata-download/issues/60

# Overview

### What is the feature?

Makes hostname checks in openUrl case-insensitive.

### What is the Solution?

Added a function that does the comparison in a case-insensitive way. Added tests for that function.

### What areas of the application does this impact?

Deeplink URLs that were case-sensitive are no longer. This allows for backend services providing EDL auth to open the `authCallback` deeplink as a redirect.

# Testing

### Reproduction steps

- **Collection to test with:**

`npm test`

### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have bumped the `version` field in package.json and ran `npm install`
