### PR TITLE
EDD-80: Fixes issue with SSL verification for some users

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,6 +3,10 @@
  * https://jestjs.io/docs/configuration
  */
 
+const esModulesToIgnore = [
+  'lodash-es'
+].join('|')
+
 module.exports = {
   // All imported modules in your tests should be mocked automatically
   // automock: false,
@@ -188,13 +192,10 @@ module.exports = {
   transform: {
     '^.+\\.(ts|js|jsx)$': 'babel-jest',
     '^.+\\.(css|less|scss)$': 'jest-css-modules-transform'
-  }
+  },
 
   // An array of regexp pattern strings that are matched against all source file paths, matched files will skip transformation
-  // transformIgnorePatterns: [
-  //   "/node_modules/",
-  //   "\\.pnp\\.[^\\/]+$"
-  // ],
+  transformIgnorePatterns: [`/node_modules/(?!${esModulesToIgnore})`]
 
   // An array of regexp pattern strings that are matched against all modules before the module loader will automatically return a mock for them
   // unmockedModulePathPatterns: undefined,

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -51,5 +51,3 @@ window.electronApi = {
   isWin: false,
   isLinux: false
 }
-
-global.fetch = jest.fn()

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -51,3 +51,5 @@ window.electronApi = {
   isWin: false,
   isLinux: false
 }
+
+global.fetch = jest.fn()

--- a/migrations/20250626153244_add_client_id_to_downloads.js
+++ b/migrations/20250626153244_add_client_id_to_downloads.js
@@ -1,0 +1,7 @@
+exports.up = (knex) => knex.schema.table('downloads', (table) => {
+  table.string('clientId').nullable().defaultTo(null)
+})
+
+exports.down = (knex) => knex.schema.table('downloads', (table) => {
+  table.dropColumn('clientId')
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "earthdata-download",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "earthdata-download",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -29,9 +29,8 @@
         "humanize-duration": "^3.28.0",
         "inter-ui": "^3.19.3",
         "knex": "^2.4.2",
-        "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21",
         "node-abi": "^4.9.0",
-        "node-fetch": "^3.3.1",
         "prop-types": "^15.8.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -8988,13 +8987,6 @@
         "node": ">=0.10"
       }
     },
-    "node_modules/data-uri-to-buffer": {
-      "version": "4.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/data-urls": {
       "version": "3.0.2",
       "dev": true,
@@ -11004,27 +10996,6 @@
         "pend": "~1.2.0"
       }
     },
-    "node_modules/fetch-blob": {
-      "version": "3.2.0",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      },
-      "engines": {
-        "node": "^12.20 || >= 14.13"
-      }
-    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "dev": true,
@@ -11220,16 +11191,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/formdata-polyfill": {
-      "version": "4.0.10",
-      "license": "MIT",
-      "dependencies": {
-        "fetch-blob": "^3.1.2"
-      },
-      "engines": {
-        "node": ">=12.20.0"
       }
     },
     "node_modules/from": {
@@ -15163,6 +15124,12 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "license": "MIT"
+    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "dev": true,
@@ -15907,39 +15874,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/node-domexception": {
-      "version": "1.0.0",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.5.0"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "3.3.1",
-      "license": "MIT",
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/node-int64": {
@@ -20761,13 +20695,6 @@
       "license": "MIT",
       "dependencies": {
         "defaults": "^1.0.3"
-      }
-    },
-    "node_modules/web-streams-polyfill": {
-      "version": "3.2.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/webidl-conversions": {
@@ -27105,9 +27032,6 @@
         "assert-plus": "^1.0.0"
       }
     },
-    "data-uri-to-buffer": {
-      "version": "4.0.1"
-    },
     "data-urls": {
       "version": "3.0.2",
       "dev": true,
@@ -28513,13 +28437,6 @@
         "pend": "~1.2.0"
       }
     },
-    "fetch-blob": {
-      "version": "3.2.0",
-      "requires": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      }
-    },
     "file-entry-cache": {
       "version": "6.0.1",
       "dev": true,
@@ -28650,12 +28567,6 @@
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "mime-types": "^2.1.12"
-      }
-    },
-    "formdata-polyfill": {
-      "version": "4.0.10",
-      "requires": {
-        "fetch-blob": "^3.1.2"
       }
     },
     "from": {
@@ -31218,6 +31129,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
+    "lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
+    },
     "lodash.debounce": {
       "version": "4.0.8",
       "dev": true
@@ -31713,17 +31629,6 @@
           "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
           "dev": true
         }
-      }
-    },
-    "node-domexception": {
-      "version": "1.0.0"
-    },
-    "node-fetch": {
-      "version": "3.3.1",
-      "requires": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
       }
     },
     "node-int64": {
@@ -34952,9 +34857,6 @@
       "requires": {
         "defaults": "^1.0.3"
       }
-    },
-    "web-streams-polyfill": {
-      "version": "3.2.1"
     },
     "webidl-conversions": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "earthdata-download",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Earthdata Download is a cross-platform download manager designed to improve how users download Earth Science data. It accepts lists of files from applications like Earthdata Search (https://search.earthdata.nasa.gov/) and enables clients to offer users a streamlined experience when downloading files from their browser.",
   "repository": "nasa/earthdata-download",
   "homepage": "https://github.com/nasa/earthdata-download#readme",
@@ -58,9 +58,8 @@
     "humanize-duration": "^3.28.0",
     "inter-ui": "^3.19.3",
     "knex": "^2.4.2",
-    "lodash": "^4.17.21",
+    "lodash-es": "^4.17.21",
     "node-abi": "^4.9.0",
-    "node-fetch": "^3.3.1",
     "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/app/components/Skeleton/Skeleton.jsx
+++ b/src/app/components/Skeleton/Skeleton.jsx
@@ -5,7 +5,7 @@ import {
   mapValues,
   isString,
   isNumber
-} from 'lodash'
+} from 'lodash-es'
 
 import * as styles from './Skeleton.module.scss'
 

--- a/src/main/config.json
+++ b/src/main/config.json
@@ -1,4 +1,4 @@
 {
   "note": "This endpoint is for EDSC CloudWatch",
-  "logging": "https://d53njncz5taqi.cloudfront.net/edd_logger"
+  "logging": "https://searchprodapi-1167262027.auto.earthdatacloud.nasa.gov/edd_logger"
 }

--- a/src/main/eventHandlers/__tests__/didFinishLoad.test.ts
+++ b/src/main/eventHandlers/__tests__/didFinishLoad.test.ts
@@ -24,11 +24,6 @@ jest.mock(
   { virtual: true }
 )
 
-jest.mock('node-fetch', () => ({
-  __esModule: true,
-  default: jest.fn()
-}))
-
 describe('did-finish-load', () => {
   describe('when the app is not packaged', () => {
     test('opens the app window', async () => {

--- a/src/main/eventHandlers/__tests__/openUrl.test.ts
+++ b/src/main/eventHandlers/__tests__/openUrl.test.ts
@@ -54,6 +54,7 @@ describe('openUrl', () => {
         'shortName_versionId-20230501_000000',
         {
           authUrl: null,
+          clientId: 'eed-edsc-dev-serverless-client',
           createdAt: 1682899200000,
           eulaRedirectUrl: null,
           getLinksToken: 'Bearer mock-token',
@@ -67,7 +68,7 @@ describe('openUrl', () => {
         eventType: metricsEvent.openUrl,
         data: {
           clientId: 'eed-edsc-dev-serverless-client',
-          downloadId: 'shortName_versionId'
+          downloadId: 'shortName_versionId-20230501_000000'
         }
       })
 
@@ -100,6 +101,7 @@ describe('openUrl', () => {
         'shortName_versionId-20230501_000000',
         {
           authUrl: null,
+          clientId: null,
           createdAt: 1682899200000,
           eulaRedirectUrl: null,
           getLinksToken: 'Bearer mock-token',
@@ -113,7 +115,7 @@ describe('openUrl', () => {
         eventType: metricsEvent.openUrl,
         data: {
           clientId: null,
-          downloadId: 'shortName_versionId'
+          downloadId: 'shortName_versionId-20230501_000000'
         }
       })
 
@@ -146,6 +148,7 @@ describe('openUrl', () => {
         'shortName_versionId-20230501_000000',
         {
           authUrl: null,
+          clientId: 'eed-edsc-dev-serverless-client',
           createdAt: 1682899200000,
           eulaRedirectUrl: null,
           getLinksToken: 'Bearer mock-token',
@@ -159,7 +162,7 @@ describe('openUrl', () => {
         eventType: metricsEvent.openUrl,
         data: {
           clientId: 'eed-edsc-dev-serverless-client',
-          downloadId: 'shortName_versionId'
+          downloadId: 'shortName_versionId-20230501_000000'
         }
       })
 

--- a/src/main/eventHandlers/__tests__/pauseDownloadItem.test.ts
+++ b/src/main/eventHandlers/__tests__/pauseDownloadItem.test.ts
@@ -87,7 +87,7 @@ describe('pauseDownloadItem', () => {
 
       expect(metricsLogger).toHaveBeenCalledTimes(1)
       expect(metricsLogger).toHaveBeenCalledWith(database, {
-        eventType: metricsEvent.DownloadPause,
+        eventType: metricsEvent.downloadPause,
         data: {
           downloadCount: 1,
           downloadIds: ['mock-download-id']
@@ -136,7 +136,7 @@ describe('pauseDownloadItem', () => {
 
       expect(metricsLogger).toHaveBeenCalledTimes(1)
       expect(metricsLogger).toHaveBeenCalledWith(database, {
-        eventType: metricsEvent.DownloadPause,
+        eventType: metricsEvent.downloadPause,
         data: {
           downloadIds: ['mock-download-id-1', 'mock-download-id-2']
         }

--- a/src/main/eventHandlers/cancelDownloadItem.ts
+++ b/src/main/eventHandlers/cancelDownloadItem.ts
@@ -3,7 +3,6 @@
 import downloadStates from '../../app/constants/downloadStates'
 import finishDownload from './willDownloadEvents/finishDownload'
 import metricsLogger from '../utils/metricsLogger'
-import downloadIdForMetrics from '../utils/downloadIdForMetrics'
 
 import metricsEvent from '../../app/constants/metricsEvent'
 
@@ -45,7 +44,7 @@ const cancelDownloadItem = async ({
     metricsLogger(database, {
       eventType: metricsEvent.downloadItemCancel,
       data: {
-        downloadId: downloadIdForMetrics(downloadId)
+        downloadId
       }
     })
   }
@@ -71,7 +70,7 @@ const cancelDownloadItem = async ({
     metricsLogger(database, {
       eventType: metricsEvent.downloadCancel,
       data: {
-        downloadIds: [downloadIdForMetrics(downloadId)],
+        downloadIds: [downloadId],
         cancelCount: 1
       }
     })
@@ -93,7 +92,7 @@ const cancelDownloadItem = async ({
     const cancelledDownloadIds = []
     await Promise.all(updatedDownloads.map(async (updatedDownload) => {
       const { id } = updatedDownload
-      cancelledDownloadIds.push(downloadIdForMetrics(id))
+      cancelledDownloadIds.push(id)
       await database.endPause(id)
     }))
 

--- a/src/main/eventHandlers/openUrl.ts
+++ b/src/main/eventHandlers/openUrl.ts
@@ -1,6 +1,5 @@
 // @ts-nocheck
 
-import downloadIdForMetrics from '../utils/downloadIdForMetrics'
 import metricsLogger from '../utils/metricsLogger'
 import startNextDownload from '../utils/startNextDownload'
 import startPendingDownloads from '../utils/startPendingDownloads'
@@ -80,6 +79,7 @@ const openUrl = async ({
     // Create a download in the database
     await database.createDownload(downloadId, {
       authUrl,
+      clientId,
       createdAt: new Date().getTime(),
       eulaRedirectUrl,
       getLinksToken,
@@ -91,7 +91,7 @@ const openUrl = async ({
       eventType: metricsEvent.openUrl,
       data: {
         clientId,
-        downloadId: downloadIdForMetrics(downloadId)
+        downloadId
       }
     })
 

--- a/src/main/eventHandlers/pauseDownloadItem.ts
+++ b/src/main/eventHandlers/pauseDownloadItem.ts
@@ -40,7 +40,7 @@ const pauseDownloadItem = async ({
     })
 
     metricsLogger(database, {
-      eventType: metricsEvent.DownloadPause,
+      eventType: metricsEvent.downloadPause,
       data: {
         downloadIds: [downloadId],
         downloadCount: 1
@@ -59,7 +59,7 @@ const pauseDownloadItem = async ({
     })
 
     metricsLogger(database, {
-      eventType: metricsEvent.DownloadPause,
+      eventType: metricsEvent.downloadPause,
       data: {
         downloadIds: pauseResponse.pausedIds
       }

--- a/src/main/eventHandlers/pauseDownloadItem.ts
+++ b/src/main/eventHandlers/pauseDownloadItem.ts
@@ -2,7 +2,6 @@
 
 import downloadStates from '../../app/constants/downloadStates'
 import metricsLogger from '../utils/metricsLogger'
-import downloadIdForMetrics from '../utils/downloadIdForMetrics'
 
 import metricsEvent from '../../app/constants/metricsEvent'
 
@@ -43,7 +42,7 @@ const pauseDownloadItem = async ({
     metricsLogger(database, {
       eventType: metricsEvent.DownloadPause,
       data: {
-        downloadIds: [downloadIdForMetrics(downloadId)],
+        downloadIds: [downloadId],
         downloadCount: 1
       }
     })
@@ -59,11 +58,10 @@ const pauseDownloadItem = async ({
       state: downloadStates.paused
     })
 
-    const metricIds = pauseResponse.pausedIds.map(downloadIdForMetrics)
     metricsLogger(database, {
       eventType: metricsEvent.DownloadPause,
       data: {
-        downloadIds: metricIds
+        downloadIds: pauseResponse.pausedIds
       }
     })
   }

--- a/src/main/eventHandlers/restartDownload.ts
+++ b/src/main/eventHandlers/restartDownload.ts
@@ -1,7 +1,6 @@
 // @ts-nocheck
 
 import downloadStates from '../../app/constants/downloadStates'
-import downloadIdForMetrics from '../utils/downloadIdForMetrics'
 import metricsEvent from '../../app/constants/metricsEvent'
 import metricsLogger from '../utils/metricsLogger'
 import startNextDownload from '../utils/startNextDownload'
@@ -32,7 +31,7 @@ const restartDownload = async ({
   metricsLogger(database, {
     eventType: metricsEvent.downloadRestart,
     data: {
-      downloadId: downloadIdForMetrics(downloadId),
+      downloadId,
       filesCompleted: report.finishedFiles,
       filesInProgress: report.totalFiles - report.finishedFiles
     }

--- a/src/main/eventHandlers/resumeDownloadItem.ts
+++ b/src/main/eventHandlers/resumeDownloadItem.ts
@@ -6,7 +6,6 @@ import downloadStates from '../../app/constants/downloadStates'
 import startNextDownload from '../utils/startNextDownload'
 import metricsEvent from '../../app/constants/metricsEvent'
 import metricsLogger from '../utils/metricsLogger'
-import downloadIdForMetrics from '../utils/downloadIdForMetrics'
 
 /**
  * Resumes a download and updates the database
@@ -41,7 +40,7 @@ const resumeDownloadItem = async ({
     metricsLogger(database, {
       eventType: metricsEvent.downloadResume,
       data: {
-        downloadIds: [downloadIdForMetrics(downloadId)],
+        downloadIds: [downloadId],
         downloadCount: 1
       }
     })
@@ -82,7 +81,7 @@ const resumeDownloadItem = async ({
         state: newState
       })
 
-      downloadIds.push(downloadIdForMetrics(id))
+      downloadIds.push(id)
     })
 
     metricsLogger(database, {

--- a/src/main/eventHandlers/sendToEula.ts
+++ b/src/main/eventHandlers/sendToEula.ts
@@ -5,7 +5,6 @@ import { shell } from 'electron'
 import downloadStates from '../../app/constants/downloadStates'
 import metricsEvent from '../../app/constants/metricsEvent'
 import metricsLogger from '../utils/metricsLogger'
-import downloadIdForMetrics from '../utils/downloadIdForMetrics'
 
 /**
  * Sends the user to the download's eulaUrl to get a new token
@@ -80,7 +79,7 @@ const sendToEula = async ({
     metricsLogger(database, {
       eventType: metricsEvent.sentToEula,
       data: {
-        downloadId: downloadIdForMetrics(downloadId)
+        downloadId
       }
     })
   }

--- a/src/main/eventHandlers/sendToLogin.ts
+++ b/src/main/eventHandlers/sendToLogin.ts
@@ -5,7 +5,6 @@ import { shell } from 'electron'
 import downloadStates from '../../app/constants/downloadStates'
 import metricsEvent from '../../app/constants/metricsEvent'
 import metricsLogger from '../utils/metricsLogger'
-import downloadIdForMetrics from '../utils/downloadIdForMetrics'
 
 /**
  * Sends the user to the download's authUrl to get a new token
@@ -74,7 +73,7 @@ const sendToLogin = async ({
     metricsLogger(database, {
       eventType: metricsEvent.sentToEdl,
       data: {
-        downloadId: downloadIdForMetrics(downloadId)
+        downloadId
       }
     })
   }

--- a/src/main/eventHandlers/willDownload.ts
+++ b/src/main/eventHandlers/willDownload.ts
@@ -13,7 +13,6 @@ import verifyDownload from '../utils/verifyDownload'
 import finishDownload from './willDownloadEvents/finishDownload'
 import metricsEvent from '../../app/constants/metricsEvent'
 import metricsLogger from '../utils/metricsLogger'
-import downloadIdForMetrics from '../utils/downloadIdForMetrics'
 
 /**
  * Handles the DownloadItem events
@@ -161,7 +160,7 @@ const willDownload = async ({
     metricsLogger(database, {
       eventType: metricsEvent.downloadErrored,
       data: {
-        downloadId: downloadIdForMetrics(downloadId),
+        downloadId,
         filename,
         reason: 'File reported a size of 0 bytes.'
       }

--- a/src/main/eventHandlers/willDownloadEvents/finishDownload.ts
+++ b/src/main/eventHandlers/willDownloadEvents/finishDownload.ts
@@ -3,7 +3,6 @@
 import downloadStates from '../../../app/constants/downloadStates'
 import metricsEvent from '../../../app/constants/metricsEvent'
 import metricsLogger from '../../utils/metricsLogger'
-import downloadIdForMetrics from '../../utils/downloadIdForMetrics'
 
 /**
  * If no more files are not completed, mark the download as completed
@@ -27,7 +26,7 @@ const finishDownload = async ({
     metricsLogger(database, {
       eventType: metricsEvent.downloadComplete,
       data: {
-        downloadId: downloadIdForMetrics(downloadId),
+        downloadId,
         receivedBytes: downloadStatistics.receivedBytesSum,
         totalBytes: downloadStatistics.totalBytesSum,
         duration: (downloadStatistics.totalDownloadTime / 1000).toFixed(1),

--- a/src/main/eventHandlers/willDownloadEvents/onDone.ts
+++ b/src/main/eventHandlers/willDownloadEvents/onDone.ts
@@ -5,7 +5,6 @@ import finishDownload from './finishDownload'
 import startNextDownload from '../../utils/startNextDownload'
 import metricsEvent from '../../../app/constants/metricsEvent'
 import metricsLogger from '../../utils/metricsLogger'
-import downloadIdForMetrics from '../../utils/downloadIdForMetrics'
 
 /**
  * Handles the DownloadItem 'done' event
@@ -63,7 +62,7 @@ const onDone = async ({
       metricsLogger(database, {
         eventType: metricsEvent.downloadErrored,
         data: {
-          downloadId: downloadIdForMetrics(downloadId),
+          downloadId,
           filename
         }
       })

--- a/src/main/eventHandlers/willDownloadEvents/onUpdated.ts
+++ b/src/main/eventHandlers/willDownloadEvents/onUpdated.ts
@@ -3,7 +3,6 @@
 import downloadStates from '../../../app/constants/downloadStates'
 import metricsEvent from '../../../app/constants/metricsEvent'
 import metricsLogger from '../../utils/metricsLogger'
-import downloadIdForMetrics from '../../utils/downloadIdForMetrics'
 
 /**
  * Handles the DownloadItem 'updated' event
@@ -53,7 +52,7 @@ const onUpdated = async ({
     metricsLogger(database, {
       eventType: metricsEvent.downloadInterrupted,
       data: {
-        downloadId: downloadIdForMetrics(downloadId),
+        downloadId,
         filename
       }
     })

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -146,30 +146,36 @@ if (!gotTheLock) {
     // The commandLine is array of strings in which last element is deep link url
     const url = commandLine.pop()
 
-    await openUrl({
-      appWindow,
-      currentDownloadItems,
-      database,
-      deepLink: url,
-      downloadIdContext,
-      downloadsWaitingForAuth,
-      downloadsWaitingForEula,
-      updateAvailable
-    })
+    // Delay the opening of the URL to ensure any new database migrations have been applied
+    setTimeout(async () => {
+      await openUrl({
+        appWindow,
+        currentDownloadItems,
+        database,
+        deepLink: url,
+        downloadIdContext,
+        downloadsWaitingForAuth,
+        downloadsWaitingForEula,
+        updateAvailable
+      })
+    }, 0)
   })
 
   // MacOS Deep Linking
   app.on('open-url', async (event, url) => {
-    await openUrl({
-      appWindow,
-      currentDownloadItems,
-      database,
-      deepLink: url,
-      downloadIdContext,
-      downloadsWaitingForAuth,
-      downloadsWaitingForEula,
-      updateAvailable
-    })
+    // Delay the opening of the URL to ensure any new database migrations have been applied
+    setTimeout(async () => {
+      await openUrl({
+        appWindow,
+        currentDownloadItems,
+        database,
+        deepLink: url,
+        downloadIdContext,
+        downloadsWaitingForAuth,
+        downloadsWaitingForEula,
+        updateAvailable
+      })
+    }, 0)
   })
 
   // Create window, load the rest of the app, etc...

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -137,6 +137,9 @@ if (!gotTheLock) {
 } else {
   // Windows/Linux Deep Linking
   app.on('second-instance', async (event, commandLine) => {
+    // Ensure the database is up to date
+    await database.migrateDatabase()
+
     // Someone tried to run a second instance, we should focus our window.
     if (appWindow) {
       if (appWindow.isMinimized()) appWindow.restore()
@@ -146,36 +149,33 @@ if (!gotTheLock) {
     // The commandLine is array of strings in which last element is deep link url
     const url = commandLine.pop()
 
-    // Delay the opening of the URL to ensure any new database migrations have been applied
-    setTimeout(async () => {
-      await openUrl({
-        appWindow,
-        currentDownloadItems,
-        database,
-        deepLink: url,
-        downloadIdContext,
-        downloadsWaitingForAuth,
-        downloadsWaitingForEula,
-        updateAvailable
-      })
-    }, 0)
+    await openUrl({
+      appWindow,
+      currentDownloadItems,
+      database,
+      deepLink: url,
+      downloadIdContext,
+      downloadsWaitingForAuth,
+      downloadsWaitingForEula,
+      updateAvailable
+    })
   })
 
   // MacOS Deep Linking
   app.on('open-url', async (event, url) => {
-    // Delay the opening of the URL to ensure any new database migrations have been applied
-    setTimeout(async () => {
-      await openUrl({
-        appWindow,
-        currentDownloadItems,
-        database,
-        deepLink: url,
-        downloadIdContext,
-        downloadsWaitingForAuth,
-        downloadsWaitingForEula,
-        updateAvailable
-      })
-    }, 0)
+    // Ensure the database is up to date
+    await database.migrateDatabase()
+
+    await openUrl({
+      appWindow,
+      currentDownloadItems,
+      database,
+      deepLink: url,
+      downloadIdContext,
+      downloadsWaitingForAuth,
+      downloadsWaitingForEula,
+      updateAvailable
+    })
   })
 
   // Create window, load the rest of the app, etc...

--- a/src/main/utils/__tests__/fetchLinks.test.ts
+++ b/src/main/utils/__tests__/fetchLinks.test.ts
@@ -86,7 +86,12 @@ describe('fetchLinks', () => {
         headers: {
           Authorization: 'Bearer mock-token'
         },
-        method: 'get'
+        method: 'get',
+        agent: expect.objectContaining({
+          options: expect.objectContaining({
+            rejectUnauthorized: false
+          })
+        })
       }
     )
 
@@ -96,7 +101,12 @@ describe('fetchLinks', () => {
         headers: {
           Authorization: 'Bearer mock-token'
         },
-        method: 'get'
+        method: 'get',
+        agent: expect.objectContaining({
+          options: expect.objectContaining({
+            rejectUnauthorized: false
+          })
+        })
       }
     )
 
@@ -173,7 +183,12 @@ describe('fetchLinks', () => {
           headers: {
             Authorization: 'Bearer mock-token'
           },
-          method: 'get'
+          method: 'get',
+          agent: expect.objectContaining({
+            options: expect.objectContaining({
+              rejectUnauthorized: false
+            })
+          })
         }
       )
 
@@ -264,7 +279,12 @@ describe('fetchLinks', () => {
           headers: {
             Authorization: 'Bearer mock-token'
           },
-          method: 'get'
+          method: 'get',
+          agent: expect.objectContaining({
+            options: expect.objectContaining({
+              rejectUnauthorized: false
+            })
+          })
         }
       )
 
@@ -274,7 +294,12 @@ describe('fetchLinks', () => {
           headers: {
             Authorization: 'Bearer mock-token'
           },
-          method: 'get'
+          method: 'get',
+          agent: expect.objectContaining({
+            options: expect.objectContaining({
+              rejectUnauthorized: false
+            })
+          })
         }
       )
 
@@ -345,7 +370,12 @@ describe('fetchLinks', () => {
         headers: {
           Authorization: 'Bearer mock-token'
         },
-        method: 'get'
+        method: 'get',
+        agent: expect.objectContaining({
+          options: expect.objectContaining({
+            rejectUnauthorized: false
+          })
+        })
       }
     )
 

--- a/src/main/utils/__tests__/fetchLinks.test.ts
+++ b/src/main/utils/__tests__/fetchLinks.test.ts
@@ -1,5 +1,7 @@
 // @ts-nocheck
 
+import { net } from 'electron'
+
 import fetchLinks from '../fetchLinks'
 import initializeDownload from '../initializeDownload'
 
@@ -7,6 +9,12 @@ import downloadStates from '../../../app/constants/downloadStates'
 import metricsEvent from '../../../app/constants/metricsEvent'
 import metricsLogger from '../metricsLogger'
 import downloadIdForMetrics from '../downloadIdForMetrics'
+
+jest.mock('electron', () => ({
+  net: {
+    fetch: jest.fn()
+  }
+}))
 
 jest.spyOn(console, 'error').mockImplementation(() => {})
 
@@ -58,7 +66,7 @@ describe('fetchLinks', () => {
       })
     }
 
-    fetch
+    net.fetch
       .mockImplementationOnce(() => page1Response)
       .mockImplementationOnce(() => page2Response)
       .mockImplementationOnce(() => page3Response)
@@ -72,34 +80,24 @@ describe('fetchLinks', () => {
       getLinksUrl
     })
 
-    expect(fetch).toHaveBeenCalledTimes(3)
-    expect(fetch).toHaveBeenCalledWith(
+    expect(net.fetch).toHaveBeenCalledTimes(3)
+    expect(net.fetch).toHaveBeenCalledWith(
       'http://localhost:3000/granule_links?id=42&flattenLinks=true&linkTypes=data&pageNum=1',
       {
         headers: {
           Authorization: 'Bearer mock-token'
         },
-        method: 'get',
-        agent: expect.objectContaining({
-          options: expect.objectContaining({
-            rejectUnauthorized: false
-          })
-        })
+        method: 'GET'
       }
     )
 
-    expect(fetch).toHaveBeenCalledWith(
+    expect(net.fetch).toHaveBeenCalledWith(
       'http://localhost:3000/granule_links?id=42&flattenLinks=true&linkTypes=data&cursor=mock-cursor',
       {
         headers: {
           Authorization: 'Bearer mock-token'
         },
-        method: 'get',
-        agent: expect.objectContaining({
-          options: expect.objectContaining({
-            rejectUnauthorized: false
-          })
-        })
+        method: 'GET'
       }
     )
 
@@ -157,7 +155,7 @@ describe('fetchLinks', () => {
         })
       }
 
-      fetch
+      net.fetch
         .mockImplementationOnce(() => page1Response)
 
       await fetchLinks({
@@ -169,19 +167,14 @@ describe('fetchLinks', () => {
         getLinksUrl
       })
 
-      expect(fetch).toHaveBeenCalledTimes(1)
-      expect(fetch).toHaveBeenCalledWith(
+      expect(net.fetch).toHaveBeenCalledTimes(1)
+      expect(net.fetch).toHaveBeenCalledWith(
         'http://localhost:3000/granule_links?id=42&flattenLinks=true&linkTypes=data&pageNum=1',
         {
           headers: {
             Authorization: 'Bearer mock-token'
           },
-          method: 'get',
-          agent: expect.objectContaining({
-            options: expect.objectContaining({
-              rejectUnauthorized: false
-            })
-          })
+          method: 'GET'
         }
       )
 
@@ -251,7 +244,7 @@ describe('fetchLinks', () => {
         })
       }
 
-      fetch
+      net.fetch
         .mockImplementationOnce(() => page1Response)
         .mockImplementationOnce(() => page2Response)
         .mockImplementationOnce(() => page3Response)
@@ -265,34 +258,24 @@ describe('fetchLinks', () => {
         getLinksUrl
       })
 
-      expect(fetch).toHaveBeenCalledTimes(3)
-      expect(fetch).toHaveBeenCalledWith(
+      expect(net.fetch).toHaveBeenCalledTimes(3)
+      expect(net.fetch).toHaveBeenCalledWith(
         'http://localhost:3000/granule_links?id=42&flattenLinks=true&linkTypes=data&pageNum=1',
         {
           headers: {
             Authorization: 'Bearer mock-token'
           },
-          method: 'get',
-          agent: expect.objectContaining({
-            options: expect.objectContaining({
-              rejectUnauthorized: false
-            })
-          })
+          method: 'GET'
         }
       )
 
-      expect(fetch).toHaveBeenCalledWith(
+      expect(net.fetch).toHaveBeenCalledWith(
         'http://localhost:3000/granule_links?id=42&flattenLinks=true&linkTypes=data&cursor=mock-cursor',
         {
           headers: {
             Authorization: 'Bearer mock-token'
           },
-          method: 'get',
-          agent: expect.objectContaining({
-            options: expect.objectContaining({
-              rejectUnauthorized: false
-            })
-          })
+          method: 'GET'
         }
       )
 
@@ -342,7 +325,7 @@ describe('fetchLinks', () => {
     const getLinksToken = 'Bearer mock-token'
     const error = new Error(downloadStates.error)
 
-    fetch
+    net.fetch
       .mockImplementationOnce(() => {
         throw error
       })
@@ -356,19 +339,14 @@ describe('fetchLinks', () => {
       getLinksUrl
     })
 
-    expect(fetch).toHaveBeenCalledTimes(1)
-    expect(fetch).toHaveBeenCalledWith(
+    expect(net.fetch).toHaveBeenCalledTimes(1)
+    expect(net.fetch).toHaveBeenCalledWith(
       'http://localhost:3000/granule_links?id=42&flattenLinks=true&linkTypes=data&pageNum=1',
       {
         headers: {
           Authorization: 'Bearer mock-token'
         },
-        method: 'get',
-        agent: expect.objectContaining({
-          options: expect.objectContaining({
-            rejectUnauthorized: false
-          })
-        })
+        method: 'GET'
       }
     )
 
@@ -425,7 +403,7 @@ describe('fetchLinks', () => {
         links: ['https://example.com/file1.png']
       })
     }
-    fetch.mockImplementation(() => standardResponse)
+    net.fetch.mockImplementation(() => standardResponse)
     const getLinksUrl = 'http://fakery/granule_links?id=301&flattenLinks=true&linkTypes=data'
     const errorMessage = `The host [${getLinksUrl}] is not a trusted source and Earthdata Download will not continue.\nIf you wish to have this link included in the list of trusted sources please contact us at support@earthdata.nasa.gov or submit a Pull Request at https://github.com/nasa/earthdata-download#readme.`
 
@@ -476,7 +454,7 @@ describe('fetchLinks', () => {
     expect(database.addLinksByDownloadId).toHaveBeenCalledTimes(0)
 
     // We should not have fetched anything
-    expect(fetch).toHaveBeenCalledTimes(0)
+    expect(net.fetch).toHaveBeenCalledTimes(0)
   })
 
   test.each([
@@ -525,7 +503,7 @@ describe('fetchLinks', () => {
     }
     const errorMessage = 'The response from the getLinks endpoint did not match the expected schema. Error: [{"instancePath":"","schemaPath":"#/type","keyword":"type","params":{"type":"object"},"message":"must be object"}]'
 
-    fetch
+    net.fetch
       .mockImplementationOnce(() => page1Response)
       .mockImplementationOnce(() => page2Response)
       .mockImplementation(() => page3Response)
@@ -580,6 +558,6 @@ describe('fetchLinks', () => {
       ['https://example.com/file1.png']
     )
 
-    expect(fetch).toHaveBeenCalledTimes(2)
+    expect(net.fetch).toHaveBeenCalledTimes(2)
   })
 })

--- a/src/main/utils/__tests__/fetchLinks.test.ts
+++ b/src/main/utils/__tests__/fetchLinks.test.ts
@@ -1,7 +1,5 @@
 // @ts-nocheck
 
-import fetch from 'node-fetch'
-
 import fetchLinks from '../fetchLinks'
 import initializeDownload from '../initializeDownload'
 
@@ -11,11 +9,6 @@ import metricsLogger from '../metricsLogger'
 import downloadIdForMetrics from '../downloadIdForMetrics'
 
 jest.spyOn(console, 'error').mockImplementation(() => {})
-
-jest.mock('node-fetch', () => ({
-  __esModule: true,
-  default: jest.fn()
-}))
 
 jest.mock('../initializeDownload', () => ({
   __esModule: true,

--- a/src/main/utils/__tests__/metricsLogger.test.ts
+++ b/src/main/utils/__tests__/metricsLogger.test.ts
@@ -70,7 +70,12 @@ describe('metricsLogger', () => {
         body: expectedBody,
         headers: {
           'Content-Type': 'application/json'
-        }
+        },
+        agent: expect.objectContaining({
+          options: expect.objectContaining({
+            rejectUnauthorized: false
+          })
+        })
       }
     )
   })
@@ -109,7 +114,12 @@ describe('metricsLogger', () => {
         }),
         headers: {
           'Content-Type': 'application/json'
-        }
+        },
+        agent: expect.objectContaining({
+          options: expect.objectContaining({
+            rejectUnauthorized: false
+          })
+        })
       }
     )
 

--- a/src/main/utils/__tests__/metricsLogger.test.ts
+++ b/src/main/utils/__tests__/metricsLogger.test.ts
@@ -16,7 +16,7 @@ jest.mock('electron', () => ({
 
 describe('metricsLogger', () => {
   const event = {
-    eventType: metricsEvent.DownloadComplete,
+    eventType: metricsEvent.downloadComplete,
     data: {
       downloadId: '1010_Test',
       fileCount: 10,
@@ -133,7 +133,7 @@ describe('metricsLogger', () => {
 
   test('should include downloadIds and clientIds in the event data when multiple downloads are provided', async () => {
     const eventWithMultipleDownloads = {
-      eventType: metricsEvent.DownloadPause,
+      eventType: metricsEvent.downloadPause,
       data: {
         downloadIds: ['1010_Test', '2020_Test']
       }

--- a/src/main/utils/__tests__/metricsLogger.test.ts
+++ b/src/main/utils/__tests__/metricsLogger.test.ts
@@ -1,5 +1,6 @@
 // @ts-nocheck
 
+import { net } from 'electron'
 import metricsEvent from '../../../app/constants/metricsEvent'
 import metricsLogger from '../metricsLogger'
 import config from '../../config.json'
@@ -7,6 +8,9 @@ import config from '../../config.json'
 jest.mock('electron', () => ({
   app: {
     getVersion: () => '1.0.0'
+  },
+  net: {
+    fetch: jest.fn()
   }
 }))
 
@@ -38,7 +42,7 @@ describe('metricsLogger', () => {
 
     await metricsLogger(database, event)
 
-    expect(fetch).toHaveBeenCalledTimes(0)
+    expect(net.fetch).toHaveBeenCalledTimes(0)
   })
 
   test('should send a POST request to the specified logging endpoint when user allows metrics', async () => {
@@ -66,20 +70,15 @@ describe('metricsLogger', () => {
 
     await metricsLogger(database, event)
 
-    expect(fetch).toHaveBeenCalledTimes(1)
-    expect(fetch).toHaveBeenCalledWith(
+    expect(net.fetch).toHaveBeenCalledTimes(1)
+    expect(net.fetch).toHaveBeenCalledWith(
       config.logging,
       {
         method: 'POST',
         body: expectedBody,
         headers: {
           'Content-Type': 'application/json'
-        },
-        agent: expect.objectContaining({
-          options: expect.objectContaining({
-            rejectUnauthorized: false
-          })
-        })
+        }
       }
     )
   })
@@ -98,7 +97,7 @@ describe('metricsLogger', () => {
 
     const expectedError = new Error('Request failed')
 
-    fetch
+    net.fetch
       .mockImplementationOnce(() => {
         throw new Error('Request failed')
       })
@@ -107,9 +106,9 @@ describe('metricsLogger', () => {
 
     await metricsLogger(database, event)
 
-    expect(fetch).toHaveBeenCalledTimes(1)
+    expect(net.fetch).toHaveBeenCalledTimes(1)
 
-    expect(fetch).toHaveBeenCalledWith(
+    expect(net.fetch).toHaveBeenCalledWith(
       config.logging,
       {
         method: 'POST',
@@ -125,12 +124,7 @@ describe('metricsLogger', () => {
         }),
         headers: {
           'Content-Type': 'application/json'
-        },
-        agent: expect.objectContaining({
-          options: expect.objectContaining({
-            rejectUnauthorized: false
-          })
-        })
+        }
       }
     )
 

--- a/src/main/utils/__tests__/metricsLogger.test.ts
+++ b/src/main/utils/__tests__/metricsLogger.test.ts
@@ -1,6 +1,5 @@
 // @ts-nocheck
 
-import fetch from 'node-fetch'
 import metricsEvent from '../../../app/constants/metricsEvent'
 import metricsLogger from '../metricsLogger'
 import config from '../../config.json'
@@ -9,11 +8,6 @@ jest.mock('electron', () => ({
   app: {
     getVersion: () => '1.0.0'
   }
-}))
-
-jest.mock('node-fetch', () => ({
-  __esModule: true,
-  default: jest.fn()
 }))
 
 describe('metricsLogger', () => {
@@ -36,7 +30,10 @@ describe('metricsLogger', () => {
       updateDownloadById: jest.fn(),
       getPreferencesByField: jest.fn().mockResolvedValue(
         0
-      )
+      ),
+      getDownloadById: jest.fn().mockResolvedValue({
+        clientId: 'test-client-id'
+      })
     }
 
     await metricsLogger(database, event)
@@ -48,7 +45,11 @@ describe('metricsLogger', () => {
     const expectedBody = JSON.stringify({
       params: {
         ...event,
-        appVersion: '1.0.0'
+        data: {
+          ...event.data,
+          appVersion: '1.0.0',
+          clientId: 'test-client-id'
+        }
       }
     })
 
@@ -57,7 +58,10 @@ describe('metricsLogger', () => {
       updateDownloadById: jest.fn(),
       getPreferencesByField: jest.fn().mockResolvedValue(
         1
-      )
+      ),
+      getDownloadById: jest.fn().mockResolvedValue({
+        clientId: 'test-client-id'
+      })
     }
 
     await metricsLogger(database, event)
@@ -86,7 +90,10 @@ describe('metricsLogger', () => {
       updateDownloadById: jest.fn(),
       getPreferencesByField: jest.fn().mockResolvedValue(
         1
-      )
+      ),
+      getDownloadById: jest.fn().mockResolvedValue({
+        clientId: 'test-client-id'
+      })
     }
 
     const expectedError = new Error('Request failed')
@@ -109,7 +116,11 @@ describe('metricsLogger', () => {
         body: JSON.stringify({
           params: {
             ...event,
-            appVersion: '1.0.0'
+            data: {
+              ...event.data,
+              appVersion: '1.0.0',
+              clientId: 'test-client-id'
+            }
           }
         }),
         headers: {

--- a/src/main/utils/__tests__/setupEventListeners.test.ts
+++ b/src/main/utils/__tests__/setupEventListeners.test.ts
@@ -95,11 +95,6 @@ jest.mock('../../eventHandlers/undoRestartingDownload')
 jest.mock('../../eventHandlers/willDownload')
 jest.mock('../../utils/startPendingDownloads')
 
-jest.mock('node-fetch', () => ({
-  __esModule: true,
-  default: jest.fn()
-}))
-
 const channels = {}
 
 jest.mock(

--- a/src/main/utils/__tests__/verifyDownload.test.ts
+++ b/src/main/utils/__tests__/verifyDownload.test.ts
@@ -1,5 +1,6 @@
 // @ts-nocheck
 
+import { net } from 'electron'
 import MockDate from 'mockdate'
 
 import verifyDownload from '../verifyDownload'
@@ -9,6 +10,12 @@ import sendToEula from '../../eventHandlers/sendToEula'
 import metricsEvent from '../../../app/constants/metricsEvent'
 import metricsLogger from '../metricsLogger'
 import downloadIdForMetrics from '../downloadIdForMetrics'
+
+jest.mock('electron', () => ({
+  net: {
+    fetch: jest.fn()
+  }
+}))
 
 jest.mock('../../eventHandlers/sendToEula', () => ({
   __esModule: true,
@@ -51,7 +58,7 @@ describe('verifyDownload', () => {
         })
       }
 
-      fetch.mockImplementationOnce(() => response)
+      net.fetch.mockImplementationOnce(() => response)
 
       const result = await verifyDownload({
         database,
@@ -64,8 +71,8 @@ describe('verifyDownload', () => {
 
       expect(result).toEqual(true)
 
-      expect(fetch).toHaveBeenCalledTimes(1)
-      expect(fetch).toHaveBeenCalledWith(
+      expect(net.fetch).toHaveBeenCalledTimes(1)
+      expect(net.fetch).toHaveBeenCalledWith(
         'http://example.com/file.png',
         expect.objectContaining({
           follow: 20,
@@ -109,7 +116,7 @@ describe('verifyDownload', () => {
         })
       }
 
-      fetch.mockImplementationOnce(() => response)
+      net.fetch.mockImplementationOnce(() => response)
 
       const result = await verifyDownload({
         database,
@@ -122,8 +129,8 @@ describe('verifyDownload', () => {
 
       expect(result).toEqual(false)
 
-      expect(fetch).toHaveBeenCalledTimes(1)
-      expect(fetch).toHaveBeenCalledWith(
+      expect(net.fetch).toHaveBeenCalledTimes(1)
+      expect(net.fetch).toHaveBeenCalledWith(
         'http://example.com/file.png',
         expect.objectContaining({
           follow: 20,
@@ -151,7 +158,7 @@ describe('verifyDownload', () => {
       }))
     })
 
-    test('does not try to fetch the file if the downloadId is waitingForEula', async () => {
+    test('does not try to net.fetch the file if the downloadId is waitingForEula', async () => {
       const downloadId = 'mock-download-id'
       const downloadsWaitingForEula = {
         [downloadId]: {}
@@ -178,7 +185,7 @@ describe('verifyDownload', () => {
 
       expect(result).toEqual(false)
 
-      expect(fetch).toHaveBeenCalledTimes(0)
+      expect(net.fetch).toHaveBeenCalledTimes(0)
 
       expect(database.updateFileById).toHaveBeenCalledTimes(0)
 
@@ -209,7 +216,7 @@ describe('verifyDownload', () => {
         statusText: 'Forbidden'
       }
 
-      fetch.mockImplementationOnce(() => response)
+      net.fetch.mockImplementationOnce(() => response)
       const result = await verifyDownload({
         database,
         downloadId,
@@ -221,8 +228,8 @@ describe('verifyDownload', () => {
 
       expect(result).toEqual(false)
 
-      expect(fetch).toHaveBeenCalledTimes(1)
-      expect(fetch).toHaveBeenCalledWith(
+      expect(net.fetch).toHaveBeenCalledTimes(1)
+      expect(net.fetch).toHaveBeenCalledWith(
         'http://example.com/file.png',
         expect.objectContaining({
           follow: 20,
@@ -268,7 +275,7 @@ describe('verifyDownload', () => {
       const fileId = 123
       const url = 'http://example.com/file.png'
 
-      fetch.mockImplementationOnce(() => undefined)
+      net.fetch.mockImplementationOnce(() => undefined)
 
       const result = await verifyDownload({
         database,
@@ -281,8 +288,8 @@ describe('verifyDownload', () => {
 
       expect(result).toEqual(false)
 
-      expect(fetch).toHaveBeenCalledTimes(1)
-      expect(fetch).toHaveBeenCalledWith(
+      expect(net.fetch).toHaveBeenCalledTimes(1)
+      expect(net.fetch).toHaveBeenCalledWith(
         'http://example.com/file.png',
         expect.objectContaining({
           follow: 20,

--- a/src/main/utils/__tests__/verifyDownload.test.ts
+++ b/src/main/utils/__tests__/verifyDownload.test.ts
@@ -1,7 +1,6 @@
 // @ts-nocheck
 
 import MockDate from 'mockdate'
-import fetch from 'node-fetch'
 
 import verifyDownload from '../verifyDownload'
 
@@ -10,11 +9,6 @@ import sendToEula from '../../eventHandlers/sendToEula'
 import metricsEvent from '../../../app/constants/metricsEvent'
 import metricsLogger from '../metricsLogger'
 import downloadIdForMetrics from '../downloadIdForMetrics'
-
-jest.mock('node-fetch', () => ({
-  __esModule: true,
-  default: jest.fn()
-}))
 
 jest.mock('../../eventHandlers/sendToEula', () => ({
   __esModule: true,

--- a/src/main/utils/database/EddDatabase.ts
+++ b/src/main/utils/database/EddDatabase.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 
-import { chunk } from 'lodash'
+import { chunk } from 'lodash-es'
 
 import downloadStates from '../../../app/constants/downloadStates'
 

--- a/src/main/utils/database/__tests__/EddDatabase.test.ts
+++ b/src/main/utils/database/__tests__/EddDatabase.test.ts
@@ -108,6 +108,8 @@ describe('EddDatabase', () => {
             name: '20250618183159_add_duplicate_count_to_files.js'
           }, {
             name: '20250618195255_add_invalid_links_to_downloads.js'
+          }, {
+            name: '20250626153244_add_client_id_to_downloads.js'
           }])
         } else if (step === 5) {
           // Query: select `name` from `knex_migrations` order by `id` asc'

--- a/src/main/utils/fetchLinks.ts
+++ b/src/main/utils/fetchLinks.ts
@@ -1,6 +1,5 @@
 // @ts-nocheck
 
-import fetch from 'node-fetch'
 import https from 'https'
 import Ajv from 'ajv'
 
@@ -53,7 +52,7 @@ const fetchLinks = async ({
     metricsLogger(database, {
       eventType: metricsEvent.fetchLinksFailed,
       data: {
-        downloadId: downloadIdForMetrics(downloadId),
+        downloadId,
         reason: message
       }
     })
@@ -120,7 +119,7 @@ const fetchLinks = async ({
         metricsLogger(database, {
           eventType: metricsEvent.fetchLinksFailed,
           data: {
-            downloadId: downloadIdForMetrics(downloadId),
+            downloadId,
             errorMessage
           }
         })
@@ -194,7 +193,7 @@ const fetchLinks = async ({
     metricsLogger(database, {
       eventType: metricsEvent.fetchLinksFailed,
       data: {
-        downloadId: downloadIdForMetrics(downloadId),
+        downloadId,
         reason
       }
     })

--- a/src/main/utils/fetchLinks.ts
+++ b/src/main/utils/fetchLinks.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 
-import https from 'https'
+import { net } from 'electron'
 import Ajv from 'ajv'
 
 import initializeDownload from './initializeDownload'
@@ -13,13 +13,8 @@ import isTrustedLink from './isTrustedLink'
 import packageDetails from '../../../package.json'
 import metricsEvent from '../../app/constants/metricsEvent'
 import metricsLogger from './metricsLogger'
-import downloadIdForMetrics from './downloadIdForMetrics'
 
 const ajv = new Ajv()
-
-const httpsAgent = new https.Agent({
-  rejectUnauthorized: false
-})
 
 /**
  * Fetches links for the given downloadId, adds links to the database.
@@ -97,10 +92,9 @@ const fetchLinks = async ({
         headers.Authorization = getLinksToken
       }
 
-      response = await fetch(updatedUrl, {
+      response = await net.fetch(updatedUrl, {
         headers,
-        method: 'get',
-        agent: httpsAgent
+        method: 'GET'
       })
 
       // eslint-disable-next-line no-await-in-loop

--- a/src/main/utils/fetchLinks.ts
+++ b/src/main/utils/fetchLinks.ts
@@ -1,6 +1,7 @@
 // @ts-nocheck
 
 import fetch from 'node-fetch'
+import https from 'https'
 import Ajv from 'ajv'
 
 import initializeDownload from './initializeDownload'
@@ -16,6 +17,10 @@ import metricsLogger from './metricsLogger'
 import downloadIdForMetrics from './downloadIdForMetrics'
 
 const ajv = new Ajv()
+
+const httpsAgent = new https.Agent({
+  rejectUnauthorized: false
+})
 
 /**
  * Fetches links for the given downloadId, adds links to the database.
@@ -95,7 +100,8 @@ const fetchLinks = async ({
 
       response = await fetch(updatedUrl, {
         headers,
-        method: 'get'
+        method: 'get',
+        agent: httpsAgent
       })
 
       // eslint-disable-next-line no-await-in-loop

--- a/src/main/utils/initializeDownload.ts
+++ b/src/main/utils/initializeDownload.ts
@@ -4,7 +4,6 @@ import { app } from 'electron'
 
 import metricsEvent from '../../app/constants/metricsEvent'
 import metricsLogger from './metricsLogger'
-import downloadIdForMetrics from '../utils/downloadIdForMetrics'
 
 /**
  * Sends a message to the renderer process to start a download for the given downloadIds.
@@ -47,11 +46,10 @@ const initializeDownload = async ({
       shouldUseDefaultLocation: !!defaultDownloadLocation
     })
 
-    const metricIds = downloadIds.map(downloadIdForMetrics)
     metricsLogger(database, {
       eventType: metricsEvent.downloadStarted,
       data: {
-        downloadIds: metricIds
+        downloadIds
       }
     })
   }

--- a/src/main/utils/metricsLogger.ts
+++ b/src/main/utils/metricsLogger.ts
@@ -28,11 +28,11 @@ const metricsLogger = async (database, event) => {
   }
 
   if (downloadIds && downloadIds.length > 0) {
-    dataWithVersion.clientIds = downloadIds.map((id) => {
-      const download = database.getDownloadById(id)
+    dataWithVersion.clientIds = await Promise.all(downloadIds.map(async (id) => {
+      const download = await database.getDownloadById(id)
 
       return download?.clientId
-    })
+    }))
 
     dataWithVersion.downloadIds = downloadIds.map(downloadIdForMetrics)
   }

--- a/src/main/utils/metricsLogger.ts
+++ b/src/main/utils/metricsLogger.ts
@@ -1,14 +1,9 @@
 // @ts-nocheck
 
-import { app } from 'electron'
-import https from 'https'
+import { app, net } from 'electron'
 
 import config from '../config.json'
 import downloadIdForMetrics from './downloadIdForMetrics'
-
-const httpsAgent = new https.Agent({
-  rejectUnauthorized: false
-})
 
 /**
  * Dispatches specified events to edd_logger lambda to be logged on CloudWatch
@@ -55,13 +50,12 @@ const metricsLogger = async (database, event) => {
   }
 
   try {
-    await fetch(config.logging, {
+    await net.fetch(config.logging, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json'
       },
-      body: JSON.stringify({ params: eventWithVersion }),
-      agent: httpsAgent
+      body: JSON.stringify({ params: eventWithVersion })
     })
   } catch (error) {
     console.error(error)

--- a/src/main/utils/metricsLogger.ts
+++ b/src/main/utils/metricsLogger.ts
@@ -12,7 +12,7 @@ import downloadIdForMetrics from './downloadIdForMetrics'
 const metricsLogger = async (database, event) => {
   const appVersion = app.getVersion()
 
-  const { data } = event
+  const { data = {} } = event
   const { downloadId, downloadIds } = data
 
   const dataWithVersion = {

--- a/src/main/utils/metricsLogger.ts
+++ b/src/main/utils/metricsLogger.ts
@@ -2,8 +2,12 @@
 
 import { app } from 'electron'
 import fetch from 'node-fetch'
+import https from 'https'
 
 import config from '../config.json'
+const httpsAgent = new https.Agent({
+  rejectUnauthorized: false
+})
 
 /**
  * Dispatches specified events to edd_logger lambda to be logged on CloudWatch

--- a/src/main/utils/metricsLogger.ts
+++ b/src/main/utils/metricsLogger.ts
@@ -42,9 +42,9 @@ const metricsLogger = async (database, event) => {
     data: dataWithVersion
   }
 
-  console.log(`Metrics Event: ${JSON.stringify(eventWithVersion)}`)
-
   const allowMetrics = await database.getPreferencesByField('allowMetrics')
+  console.log(`Metrics Event (Reported: ${allowMetrics}): ${JSON.stringify(eventWithVersion)}`)
+
   if (!allowMetrics) {
     return
   }

--- a/src/main/utils/verifyDownload.ts
+++ b/src/main/utils/verifyDownload.ts
@@ -1,14 +1,11 @@
 // @ts-nocheck
 
-import fetch from 'node-fetch'
-
 import AbortController from 'abort-controller'
 
 import downloadStates from '../../app/constants/downloadStates'
 import sendToEula from '../eventHandlers/sendToEula'
 import metricsEvent from '../../app/constants/metricsEvent'
 import metricsLogger from './metricsLogger'
-import downloadIdForMetrics from './downloadIdForMetrics'
 
 /**
  * Verify the download works and log any errors. Also redirects the user to accept a EULA if that is detected.
@@ -102,7 +99,7 @@ const verifyDownload = async ({
     metricsLogger(database, {
       eventType: metricsEvent.downloadErrored,
       data: {
-        downloadId: downloadIdForMetrics(downloadId),
+        downloadId,
         reason: errorMessage
       }
     })

--- a/src/main/utils/verifyDownload.ts
+++ b/src/main/utils/verifyDownload.ts
@@ -1,5 +1,6 @@
 // @ts-nocheck
 
+import { net } from 'electron'
 import AbortController from 'abort-controller'
 
 import downloadStates from '../../app/constants/downloadStates'
@@ -39,7 +40,7 @@ const verifyDownload = async ({
 
   let response
   try {
-    response = await fetch(url, {
+    response = await net.fetch(url, {
       method: 'GET',
       headers,
       signal: controller.signal,


### PR DESCRIPTION
# Overview

### What is the feature?

Some users were experiencing issues communicating with the EDSC API to fetch download links.

### What is the Solution?

Switching from using node-fetch to using [Electron's net.fetch
](https://www.electronjs.org/docs/latest/api/net#netfetchinput-init) resolved the issue.

I also have added the clientId to more metrics events for better metrics tracking.

### What areas of the application does this impact?

fetchLinks

# Testing

To test I created a test release and had @rupesh2 verify that downloads succeed on his machine.
General regression testing will be useful as well.

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have bumped the `version` field in package.json and ran `npm install`
