### PR TITLE
EDD-81: Sends the user to login again when their token has expired

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -51,5 +51,3 @@ window.electronApi = {
   isWin: false,
   isLinux: false
 }
-
-global.fetch = jest.fn()

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -51,3 +51,5 @@ window.electronApi = {
   isWin: false,
   isLinux: false
 }
+
+global.fetch = jest.fn()

--- a/src/main/eventHandlers/__tests__/willDownload.test.ts
+++ b/src/main/eventHandlers/__tests__/willDownload.test.ts
@@ -395,6 +395,7 @@ describe('willDownload', () => {
       expect(verifyDownload).toHaveBeenCalledTimes(1)
       expect(verifyDownload).toHaveBeenCalledWith(expect.objectContaining({
         downloadId: 'mock-download-id',
+        downloadsWaitingForAuth: {},
         downloadsWaitingForEula: {},
         fileId: 123,
         url: 'http://example.com/mock-filename.png'
@@ -468,6 +469,7 @@ describe('willDownload', () => {
       expect(verifyDownload).toHaveBeenCalledTimes(1)
       expect(verifyDownload).toHaveBeenCalledWith(expect.objectContaining({
         downloadId: 'mock-download-id',
+        downloadsWaitingForAuth: {},
         downloadsWaitingForEula: {},
         fileId: 123,
         url: 'http://example.com/mock-filename.png'

--- a/src/main/eventHandlers/willDownload.ts
+++ b/src/main/eventHandlers/willDownload.ts
@@ -131,6 +131,7 @@ const willDownload = async ({
   const downloadCheck = await verifyDownload({
     database,
     downloadId,
+    downloadsWaitingForAuth,
     downloadsWaitingForEula,
     fileId,
     url: lastUrl,

--- a/src/main/utils/__tests__/metricsLogger.test.ts
+++ b/src/main/utils/__tests__/metricsLogger.test.ts
@@ -16,7 +16,7 @@ jest.mock('electron', () => ({
 
 describe('metricsLogger', () => {
   const event = {
-    eventType: metricsEvent.downloadComplete,
+    eventType: metricsEvent.DownloadComplete,
     data: {
       downloadId: '1010_Test',
       fileCount: 10,

--- a/src/main/utils/__tests__/metricsLogger.test.ts
+++ b/src/main/utils/__tests__/metricsLogger.test.ts
@@ -16,7 +16,7 @@ jest.mock('electron', () => ({
 
 describe('metricsLogger', () => {
   const event = {
-    eventType: metricsEvent.DownloadComplete,
+    eventType: metricsEvent.downloadComplete,
     data: {
       downloadId: '1010_Test',
       fileCount: 10,

--- a/src/main/utils/metricsLogger.ts
+++ b/src/main/utils/metricsLogger.ts
@@ -43,7 +43,7 @@ const metricsLogger = async (database, event) => {
   }
 
   const allowMetrics = await database.getPreferencesByField('allowMetrics')
-  console.log(`Metrics Event (Reported: ${allowMetrics}): ${JSON.stringify(eventWithVersion)}`)
+  console.log(`Metrics Event (Reported: ${!!allowMetrics}): ${JSON.stringify(eventWithVersion)}`)
 
   if (!allowMetrics) {
     return


### PR DESCRIPTION
# Overview

### What is the feature?

When the user's EDL token has expired downloads are throwing errors instead of sending the user to login again.

### What is the Solution?

Summarize what you changed.

### What areas of the application does this impact?

Downloads with expired tokens

# Testing

Get an expired token and insert it into the tokens table in your database, start/restart a download. Ensure you are redirected to login and the download completes successfully

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have bumped the `version` field in package.json and ran `npm install`
