### PR TITLE
Add GES DISC trusted sources

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "earthdata-download",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "earthdata-download",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "earthdata-download",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Earthdata Download is a cross-platform download manager designed to improve how users download Earth Science data. It accepts lists of files from applications like Earthdata Search (https://search.earthdata.nasa.gov/) and enables clients to offer users a streamlined experience when downloading files from their browser.",
   "repository": "nasa/earthdata-download",
   "homepage": "https://github.com/nasa/earthdata-download#readme",

--- a/src/main/trustedSources.json
+++ b/src/main/trustedSources.json
@@ -12,5 +12,7 @@
   "nsidc.org": { "notes": "Corresponds to NSIDC production" },
   "integration.nsidc.org": { "notes": "Corresponds to NSIDC integration env" },
   "staging.nsidc.org": { "notes": "Corresponds to NSIDC staging env" },
-  "qa.nsidc.org": { "notes": "Corresponds to NSIDC QA env" }
+  "qa.nsidc.org": { "notes": "Corresponds to NSIDC QA env" },
+  "disc.gsfc.nasa.gov": { "notes": "Corresponds to the GES DISC production environment"  },
+  "uui-test.gesdisc.eosdis.nasa.gov": { "notes": "Corresponds to the GES DISC test environment"  }
 }


### PR DESCRIPTION
# Overview

### What is the feature?

This PR adds GES DISC domains to the trusted sources list to allow for downloading via our website and Giovanni tools.

### What is the Solution?

Added GES DISC PROD and UAT domains to the trusted sources list.

### What areas of the application does this impact?

`src/main/trustedSources.json`

# Testing

### Reproduction steps

No new tests added.

### Attachments

No attachments.

# Checklist

- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have bumped the `version` field in package.json and ran `npm install`
