### PR TITLE
EDD-63: Add version number to the downloads page

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
       <span class="header__secondary-heading">
         Download your Earth science data with only one click
       </span>
+      <span class="header__version" id="versionNumber" hidden></span>
     </header>
     <section class="primary-download primary-download--macos">
       <a class="button button--primary primary-download__link" href="%VITE_OS_MACOS_DMG_DOWNLOAD_LINK%" id="macDownloadButton" disabled>

--- a/js/util/setVersionNumber.js
+++ b/js/util/setVersionNumber.js
@@ -1,0 +1,43 @@
+const RELEASES_API_URL = 'https://api.github.com/repos/nasa/earthdata-download/releases/latest'
+
+/**
+ * Fetches the latest published release tag from the GitHub API.
+ * The download buttons always link to `releases/latest`, so the tag returned
+ * here matches the version a user is about to download.
+ * @returns {Promise<string|null>} The version string (e.g. `1.0.9`) or null if it could not be determined.
+ */
+export async function getLatestVersion() {
+  try {
+    const response = await fetch(RELEASES_API_URL, {
+      headers: { Accept: 'application/vnd.github+json' }
+    })
+
+    if (!response.ok) return null
+
+    const { tag_name: tagName } = await response.json()
+
+    if (!tagName) return null
+
+    // Release tags are prefixed with `v` (e.g. `v1.0.9`); strip it for display.
+    return tagName.replace(/^v/, '')
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Populates the given element with the latest release version and reveals it.
+ * If the version cannot be determined the element is left hidden so the page
+ * degrades gracefully.
+ * @param {HTMLElement} element The element to display the version in.
+ */
+export async function setVersionNumber(element) {
+  if (!element) return
+
+  const version = await getLatestVersion()
+
+  if (!version) return
+
+  element.textContent = `Version ${version}`
+  element.removeAttribute('hidden')
+}

--- a/main.js
+++ b/main.js
@@ -1,5 +1,7 @@
 import './style.scss'
 
 import { setOSClassName } from './js/util/setOSClassName'
+import { setVersionNumber } from './js/util/setVersionNumber'
 
 setOSClassName(document.body)
+setVersionNumber(document.getElementById('versionNumber'))

--- a/style.scss
+++ b/style.scss
@@ -133,10 +133,18 @@ a {
   }
 
   &__secondary-heading {
-    margin-bottom: 3rem;
+    margin-bottom: 1rem;
     color: var(--color__gray-dark);
     font-size: 1.5rem;
     font-weight: 300;
+    text-align: center;
+  }
+
+  &__version {
+    margin-bottom: 3rem;
+    color: var(--color__gray-dark);
+    font-size: 0.875rem;
+    font-weight: 400;
     text-align: center;
   }
 }


### PR DESCRIPTION
## Summary

Resolves #63 by displaying the current version number on the [Earthdata Download downloads page](https://nasa.github.io/earthdata-download/), so users can clearly see which version they are downloading.

## Approach

The version is shown in the page header, just below the tagline (e.g. `Version 1.0.8`).

Because every download button links to `releases/latest`, the displayed version is sourced at runtime from the GitHub releases API (`/repos/nasa/earthdata-download/releases/latest`) and the `v` prefix is stripped for display. This guarantees the number shown always matches the artifact the user actually downloads and **stays in sync with future releases automatically**, with no manual updates needed — addressing the use case raised at NSIDC of quickly confirming which release users need.

If the version can't be determined (e.g. the API is unreachable), the element stays hidden so the page degrades gracefully.

## Changes

- `index.html` — add a hidden `#versionNumber` element in the header
- `js/util/setVersionNumber.js` — new util that fetches the latest release tag and populates the element
- `main.js` — wire up the new util
- `style.scss` — style the version text to match the header

## Testing

- `npm run build` succeeds
- Verified the API call resolves the correct latest version at runtime

## Notes / open questions

Happy to adjust the placement or wording if the team has a preferred location for the version. An alternative would be sourcing the version at build time from the app's `package.json`, but since the gh-pages deploy only triggers on pushes to `download-page` (not on each app release), that value would go stale — the runtime approach avoids that.